### PR TITLE
Deprecate force_bytes and force_text functions

### DIFF
--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
 import pkg_resources
+import sys
+import warnings
 
 from .abi import (  # noqa: F401
     event_abi_to_log_topic,
@@ -78,6 +80,14 @@ from .types import (  # noqa: F401
     is_string,
     is_text,
 )
+
+
+if sys.version_info.major < 3:
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn(DeprecationWarning(
+        "The `eth-utils` library is dropping support for Python 2.  Upgrade to Python 3."
+    ))
+    warnings.resetwarnings()
 
 
 __version__ = pkg_resources.get_distribution("eth_utils").version

--- a/eth_utils/string.py
+++ b/eth_utils/string.py
@@ -1,15 +1,32 @@
-import functools
 import codecs
+import functools
+import warnings
 
 from .types import (
     is_bytes,
-    is_text,
-    is_string,
     is_dict,
     is_list_like,
+    is_string,
+    is_text,
 )
 
 
+def _deprecated(fn):
+    def inner(*args, **kwargs):
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(DeprecationWarning(
+            "The `{0}` function has been deprecated and will be removed in a "
+            "subsequent release of the eth-utils libary.  UTF8 cannot encode "
+            "some byte values in the 0-255 range which makes naive coersion between "
+            "bytes and text representations impossible without explicitly "
+            "declared encodings.".format(fn.__name__)
+        ))
+        warnings.resetwarnings()
+        return fn(*args, **kwargs)
+    return inner
+
+
+@_deprecated
 def force_bytes(value, encoding='iso-8859-1'):
     if is_bytes(value):
         return bytes(value)
@@ -19,6 +36,7 @@ def force_bytes(value, encoding='iso-8859-1'):
         raise TypeError("Unsupported type: {0}".format(type(value)))
 
 
+@_deprecated
 def force_text(value, encoding='iso-8859-1'):
     if is_text(value):
         return value
@@ -28,6 +46,7 @@ def force_text(value, encoding='iso-8859-1'):
         raise TypeError("Unsupported type: {0}".format(type(value)))
 
 
+@_deprecated
 def force_obj_to_bytes(obj):
     if is_string(obj):
         return force_bytes(obj)
@@ -41,6 +60,7 @@ def force_obj_to_bytes(obj):
         return obj
 
 
+@_deprecated
 def force_obj_to_text(obj):
     if is_string(obj):
         return force_text(obj)
@@ -54,6 +74,7 @@ def force_obj_to_text(obj):
         return obj
 
 
+@_deprecated
 def coerce_args_to_bytes(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -63,6 +84,7 @@ def coerce_args_to_bytes(fn):
     return inner
 
 
+@_deprecated
 def coerce_args_to_text(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -72,6 +94,7 @@ def coerce_args_to_text(fn):
     return inner
 
 
+@_deprecated
 def coerce_return_to_bytes(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -79,6 +102,7 @@ def coerce_return_to_bytes(fn):
     return inner
 
 
+@_deprecated
 def coerce_return_to_text(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):


### PR DESCRIPTION
### What was wrong?

The `force_bytes` and `force_text` and related functions are fundamentally broken.  It's not possible to naively convert between bytes/text representations without explicit encodings.  Worse, these functions use "latin-1" encodings which is not intuitive and results in unexpected errors since people tend to expect utf8 these days.

### How was it fixed?

Work in progress

* [ ] mark base `force_text` and `force_bytes` functions deprecated
* [ ] raise deprecation warnings for any other functions which use these utils who's function signature will change.
* [ ] migrate utils from web3 repo for conversion to/from bytes and to/from text
* [ ] figure out how to convert current functions to use new utils.

#### Cute Animal Picture

![1b1f073f2ab16fcdcac3c0d98e4d5767--baby-dachshund-long-haired-dachshund](https://user-images.githubusercontent.com/824194/33449896-552fa73e-d5c7-11e7-893a-f0918ac6766f.jpg)

