### PR TITLE
fix places where python library was named eth_utils

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.7.2
+-----
+
+* Minor fix for how `__version__` is computed in the `eth_utils` module.
+
 0.7.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ethereum Utils
 
-[![Join the chat at https://gitter.im/ethereum/eth_utils](https://badges.gitter.im/ethereum/eth-utils.svg)](https://gitter.im/ethereum/eth-utils)
+[![Join the chat at https://gitter.im/ethereum/eth-utils](https://badges.gitter.im/ethereum/eth-utils.svg)](https://gitter.im/ethereum/eth-utils)
 
-[![Build Status](https://travis-ci.org/ethereum/eth_utils.png)](https://travis-ci.org/ethereum/eth-utils)
+[![Build Status](https://travis-ci.org/ethereum/eth-utils.png)](https://travis-ci.org/ethereum/eth-utils)
 
 
 Common utility functions for codebases which interact with ethereum.

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -80,4 +80,4 @@ from .types import (  # noqa: F401
 )
 
 
-__version__ = pkg_resources.get_distribution("eth_utils").version
+__version__ = pkg_resources.get_distribution("eth-utils").version


### PR DESCRIPTION
Fixes #31

### What was wrong?

There were a few places where the python library was referenced as `eth_utils` when it should have been `eth-utils`

### How was it fixed?

Changed them to be `eth-utils`

#### Cute Animal Picture

![2cfa41b9c287e821fbd335a303ea8de7--long-haired-dachshund-dachshund-dog](https://user-images.githubusercontent.com/824194/34117529-36daefc6-e3d9-11e7-9f8b-7543d35a5635.jpg)
