### PR TITLE
expand tests to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: python
-python:
-  - "3.5"
-env:
-  matrix:
-    - TOX_ENV=py27
-    - TOX_ENV=py34
-    - TOX_ENV=py35
-    - TOX_ENV=flake8
+matrix:
+  include:
+    - python: "2.7"
+      env: TOX_ENV=py27
+    - python: "3.4"
+      env: TOX_ENV=py34
+    - python: "3.5"
+      env: TOX_ENV=py35
+    - python: "3.6"
+      env: TOX_ENV=py36
+    - python: "3.5"
+      env: TOX_ENV=flake8
 cache:
   pip: true
 install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ tox>=1.8.0
 hypothesis>=3.4.2
 flake8==3.0.4
 bumpversion==0.5.3
+when-changed

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35}
+    py{27,34,35,36}
     flake8
 
 [flake8]
@@ -17,6 +17,7 @@ basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
### What was wrong?

Python 3.6 should be supported.

### How was it fixed?

Expanded tests to test against 3.6

#### Cute Animal Picture

![a3de5dc2608a46d04aa0e190503bba36--tiny-dog-dachshunds](https://user-images.githubusercontent.com/824194/34117821-156c0a4a-e3da-11e7-8e1e-96548f461843.jpg)
