### PR TITLE
Constrain dependencies to major version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     url='https://github.com/ethereum/eth_utils',
     include_package_data=True,
     install_requires=[
-        "pysha3>=0.3",
-        "cytoolz>=0.8.2",
+        "pysha3>=1.0.0,<2.0.0",
+        "cytoolz>=0.8.2,<1.0.0",
     ],
     setup_requires=['setuptools-markdown'],
     py_modules=['eth_utils'],


### PR DESCRIPTION
### What was wrong?

Builds shouldn't automatically update major version of dependency.
Like https://github.com/ethereum/web3.py/pull/523

### How was it fixed?

Lock down major version in setup.py. Note that pysha3 seems broken in <1 (at least at 0.3), so the major version was locked to `v1.*`.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/f7/20/01/f720012d4992c0e8b84936cdffd27e38--welsh-terrier-terrier-dogs.jpg)