### PR TITLE
Tool to generate environment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,32 @@ Decimal('1.23456789E-10')
 ```
 
 
+### Debug Utils
+
+#### Generate environment info
+
+At the shell:
+
+```sh
+$ python -m eth_utils
+
+Python version:
+3.5.3 (default, Nov 23 2017, 11:34:05) 
+[GCC 6.3.0 20170406]
+
+Operating System: Linux-4.10.0-42-generic-x86_64-with-Ubuntu-17.04-zesty
+
+pip freeze result:
+bumpversion==0.5.3
+cytoolz==0.9.0
+flake8==3.4.1
+ipython==6.2.1
+pytest==3.3.2
+virtualenv==15.1.0
+... etc
+```
+
+
 ### Encoding Utils
 
 #### `big_endian_to_int(value)` -> integer

--- a/eth_utils/__main__.py
+++ b/eth_utils/__main__.py
@@ -1,0 +1,5 @@
+from .debug import (
+    get_environment_summary,
+)
+
+print(get_environment_summary())

--- a/eth_utils/debug.py
+++ b/eth_utils/debug.py
@@ -1,0 +1,24 @@
+import platform
+import subprocess
+import sys
+
+
+def pip_freeze():
+    result = subprocess.run('pip freeze'.split(), stdout=subprocess.PIPE)
+    return "pip freeze result:\n%s" % result.stdout.decode()
+
+
+def python_version():
+    return "Python version:\n%s" % sys.version
+
+
+def platform_info():
+    return "Operating System: %s" % platform.platform()
+
+
+def get_environment_summary():
+    return '\n\n'.join([
+        python_version(),
+        platform_info(),
+        pip_freeze(),
+    ])


### PR DESCRIPTION
### What was wrong?

People often leave out details of their environment when reporting a bug (or answer from memory). Let's make it painfully easy to report the info we want.

### How was it fixed?

At shell, generate info with: `python -m eth_utils`

Example Output:

```sh
$ python -m eth_utils 
Python version:
3.5.3 (default, Nov 23 2017, 11:34:05) 
[GCC 6.3.0 20170406]

Operating System: Linux-4.10.0-42-generic-x86_64-with-Ubuntu-17.04-zesty

pip freeze result:
apipkg==1.4
attrs==17.4.0
bumpversion==0.5.3
cytoolz==0.9.0
decorator==4.2.1
-e git+git@github.com:ethereum/eth-account.git@0812bb5bf31fa08e9be21d83ae79cd49681c6b16#egg=eth_account
eth-keyfile==0.4.1
eth-keys==0.1.0b4
-e git+git@github.com:ethereum/eth-rlp.git@b640ba7531cc04e2addf10f927fab91fb7015c2e#egg=eth_rlp
-e git+git@github.com:pipermerriam/ethereum-utils.git@0e1af14d44d20e3ff7717eb769ddd7185a88214d#egg=eth_utils
execnet==1.5.0
flake8==3.4.1
-e git+git@github.com:carver/ethereum-python-project-template.git@aa107a7258a9ab30bd7d2cc8b091ed385e4a8da0#egg=hexbytes
ipython==6.2.1
ipython-genutils==0.2.0
isort==4.2.15
jedi==0.11.1
mccabe==0.6.1
parso==0.1.1
pexpect==4.3.1
pickleshare==0.7.4
pluggy==0.6.0
prompt-toolkit==1.0.15
ptyprocess==0.5.2
py==1.5.2
pycodestyle==2.3.1
pycryptodome==3.4.7
pyflakes==1.5.0
Pygments==2.2.0
pysha3==1.0.2
pytest==3.3.2
pytest-forked==0.2
pytest-xdist==1.22.0
rlp==0.6.0
simplegeneric==0.8.1
six==1.11.0
toolz==0.9.0
tox==2.9.1
traitlets==4.3.2
virtualenv==15.1.0
wcwidth==0.1.7
```

#### Cute Animal Picture

![Cute animal picture](http://cdn.smosh.com/sites/default/files/bloguploads/baby-deadly-alligator.jpg)
