### PR TITLE
add zpad_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,12 @@ Returns `value` padded to the length specified by `to_size` with the string `pad
 'test12312'
 ```
 
+#### `zpad_bytes(to_size, value)`
+
+A convenience method, easily curry-able for passing a value through a pipeline of formatters.
+
+Equivalent to `pad_left(value, to_size, b'\x00')`, but accepting only `bytes` arguments.
+
 
 ### Functional Utils
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -37,6 +37,7 @@ from .encoding import (  # noqa: F401
 from .formatting import (  # noqa: F401
     pad_left,
     pad_right,
+    zpad_bytes,
 )
 from .functional import (  # noqa: F401
     apply_to_return_value,

--- a/eth_utils/formatting.py
+++ b/eth_utils/formatting.py
@@ -1,3 +1,7 @@
+from cytoolz import (
+    curry,
+)
+
 from .string import (
     force_bytes,
     force_text,
@@ -37,3 +41,11 @@ def is_prefixed(value, prefix):
     return value.startswith(
         force_bytes(prefix) if is_bytes(value) else force_text(prefix)
     )
+
+
+@curry
+def pad_bytes(fill_with, num_bytes, unpadded):
+    return unpadded.rjust(num_bytes, fill_with)
+
+
+zpad_bytes = pad_bytes(b'\0')

--- a/tests/formatting-utils/test_padding_left_and_right.py
+++ b/tests/formatting-utils/test_padding_left_and_right.py
@@ -1,5 +1,13 @@
 import pytest
 
+from hypothesis import (
+    strategies as st,
+    given,
+)
+
+from eth_utils import (
+    zpad_bytes,
+)
 from eth_utils.formatting import (
     pad_left,
     pad_right,
@@ -35,4 +43,11 @@ def test_pad_left(value, to_size, pad_with, expected):
 )
 def test_pad_right(value, to_size, pad_with, expected):
     actual = pad_right(value, to_size, pad_with)
+    assert actual == expected
+
+
+@given(st.binary(), st.integers(min_value=0))
+def test_zpad_bytes(unpadded_val, pad_to_size):
+    actual = zpad_bytes(pad_to_size, unpadded_val)
+    expected = pad_left(unpadded_val, pad_to_size, b'\0')
     assert actual == expected


### PR DESCRIPTION
### What was wrong?

I wanted an easy-to-curry function for left-padding `bytes` values in a pipeline. (so `unpadded_value` is the last argument)

See Issue #47 

### How was it fixed?

Added `pad_bytes`. It's essentially just an argument reorder of `pad_left`, for currying. Plus a version that specifically zero-pads. It's easy for people to accidentally pad with the character `b'0'` instead of `b'\x00'`, and it's a common use case.

I'm a little ambivalent about this one. It has only been used in `eth-account` so far, but the use case seems pretty clean. If you think it's not worth adding to `eth-utils` feel free to close without discussion. I will just add it straight to `eth-account` then.

#### Cute Animal Picture

![Cute animal picture](https://img.buzzfeed.com/buzzfeed-static/static/2014-05/enhanced/webdr06/7/16/enhanced-20297-1399496174-2.jpg?downsize=715:*&output-format=auto&output-quality=auto)
