### PR TITLE
Import many of the application functions from web3.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,32 @@ have no matching formatter.
 ```
 
 
+#### `apply_key_map(formatter_dict, <dict_like>)` -> `dict`
+
+This curry-able function will rename keys from <dict_like> using the
+lookups provided in `formatter_dict`. It will pass through any unspecified keys.
+
+```py
+>>> from eth_utils import apply_key_map
+
+>>> dict_key_map = apply_key_map({
+    'black': 'orange',
+    'Internet': 'Ethereum',
+})
+
+>>> dict_key_map({
+    'black': 1.2,
+    'Internet': 3.4,
+    'pass_through': 5.6,
+})
+{
+    'orange': 1.2,
+    'Ethereum': 3.4,
+    'pass_through': 5.6,
+}
+```
+
+
 
 ### Address Utils
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ def i_put_my_thing_down_flip_it_and_reverse_it(lyric):
 
 #### `apply_formatter_if(condition, formatter, value)` -> new_value
 
-This curried function will apply the formatter only if `bool(condition()) is True`.
+This curry-able function will apply the formatter only if `bool(condition()) is True`.
 
 ```py
 >>> from eth_utils import apply_formatter_if, is_string
@@ -158,7 +158,7 @@ False
 
 #### `apply_one_of_formatters(condition_formatter_pairs, value)` -> new_value
 
-This curried function will iterate through `condition_formatter_pairs`, and
+This curry-able function will iterate through `condition_formatter_pairs`, and
 apply the first formatter which has a truthy condition. One of the formatters
 *must* match, or this function will raise a `ValueError`.
 
@@ -175,6 +175,21 @@ apply the first formatter which has a truthy condition. One of the formatters
 (1, 2)
 >>> multi_formatter(54)
 ValueError("The provided value did not satisfy any of the formatter conditions")
+```
+
+
+#### `apply_formatter_at_index(formatter, at_index, <list_like>)` -> <new_list>
+
+This curry-able function will apply the formatter to one element of `list_like`,
+at position `at_index`, and return a new list with that element replaced.
+
+```py
+>>> from eth_utils import apply_formatter_at_index
+
+>>> targetted_formatter = apply_formatter_at_index(bool, 1)
+
+>>> targetted_formatter((1, 2, 3))
+[1, True, 3]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -211,18 +211,22 @@ This curry-able function will apply the formatter to each element of `list_like`
 ```
 
 
-#### `combine_argument_formatters(*formatters)` -> lambda <list_like>: list
+#### `combine_argument_formatters(*formatters)` -> lambda <list_like>: <new_list_like>
 
 Combine several formatters to be applied to a list-like value, each formatter
-at the position it was supplied. For example:
+at the position it was supplied. The new formatter will return the same type as
+it was supplied. For example:
 
 ```py
 >>> from eth_utils import combine_argument_formatters
 
 >>> list_formatter = combine_argument_formatters(bool, int, str)
 
->>> list_formatter((1.2, 3.4, 5.6))
+>>> list_formatter([1.2, 3.4, 5.6])
 [True, 3, '5.6']
+
+>>> list_formatter((1.2, 3.4, 5.6))
+(True, 3, '5.6')
 
 # it will pass through items longer than the number of formatters supplied
 >>> list_formatter((1.2, 3.4, 5.6, 7.8))

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Alternatively, you can get the curried version of the functions by importing the
 through the `curried` module like so:
 
 ```py
-from eth_utils.curried import apply_formatters_to_dict
+from eth_utils.curried import hexstr_if_str
 ```
 
 ### ABI Utils

--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ at position `at_index`, and return a new list with that element replaced.
 ```
 
 
+#### `combine_argument_formatters(*formatters)` -> lambda <list_like>: list
+
+Combine several formatters to be applied to a list-like value, each formatter
+at the position it was supplied. For example:
+
+```py
+>>> from eth_utils import combine_argument_formatters
+
+>>> list_formatter = combine_argument_formatters(bool, int, str)
+
+>>> list_formatter((1.2, 3.4, 5.6))
+[True, 3, '5.6']
+
+# it will pass through items longer than the number of formatters supplied
+>>> list_formatter((1.2, 3.4, 5.6, 7.8))
+[True, 3, '5.6', 7.8]
+```
+
+
 ### Address Utils
 
 #### `is_address(value)` -> bool

--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ False
 ```
 
 
+#### `apply_one_of_formatters(condition_formatter_pairs, value)` -> new_value
+
+This curried function will iterate through `condition_formatter_pairs`, and
+apply the first formatter which has a truthy condition. One of the formatters
+*must* match, or this function will raise a `ValueError`.
+
+```py
+>>> from eth_utils import apply_one_of_formatters, is_string, is_list_like
+
+>>> multi_formatter = apply_one_of_formatters((
+    (is_list_like, tuple),
+    (is_string, i_put_my_thing_down_flip_it_and_reverse_it),
+)
+>>> multi_formatter('my thing')
+'gniht ym'
+>>> multi_formatter([1, 2])
+(1, 2)
+>>> multi_formatter(54)
+ValueError("The provided value did not satisfy any of the formatter conditions")
+```
+
+
 ### Address Utils
 
 #### `is_address(value)` -> bool

--- a/README.md
+++ b/README.md
@@ -178,10 +178,11 @@ ValueError("The provided value did not satisfy any of the formatter conditions")
 ```
 
 
-#### `apply_formatter_at_index(formatter, at_index, <list_like>)` -> <new_list>
+#### `apply_formatter_at_index(formatter, at_index, <list_like>)` -> <new_list_like>
 
 This curry-able function will apply the formatter to one element of `list_like`,
-at position `at_index`, and return a new list with that element replaced.
+at position `at_index`, and return a new iterable with that element replaced.
+The returned value will be the same type as the one passed into the third argument.
 
 ```py
 >>> from eth_utils import apply_formatter_at_index
@@ -189,6 +190,9 @@ at position `at_index`, and return a new list with that element replaced.
 >>> targetted_formatter = apply_formatter_at_index(bool, 1)
 
 >>> targetted_formatter((1, 2, 3))
+(1, True, 3)
+
+>>> targetted_formatter([1, 2, 3])
 [1, True, 3]
 ```
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,34 @@ at the position it was supplied. For example:
 ```
 
 
+#### `apply_formatters_to_dict(formatter_dict, <dict_like>)` -> `dict`
+
+This curry-able function will apply the formatter to the element with
+the matching key in `dict_like`, passing through values with keys that
+have no matching formatter.
+
+```py
+>>> from eth_utils import apply_formatters_to_dict
+
+>>> dict_formatter = apply_formatters_to_dict({
+    'should_be_int': int,
+    'should_be_bool': bool,
+})
+
+>>> dict_formatter({
+    'should_be_int': 1.2,
+    'should_be_bool': 3.4,
+    'pass_through': 5.6,
+})
+{
+    'should_be_int': 1,
+    'should_be_bool': True,
+    'pass_through': 5.6,
+}
+```
+
+
+
 ### Address Utils
 
 #### `is_address(value)` -> bool

--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ at position `at_index`, and return a new list with that element replaced.
 ```
 
 
+#### `apply_formatter_to_array(formatter, <list_like>)` -> <new_list>
+
+This curry-able function will apply the formatter to each element of `list_like`.
+
+```py
+>>> from eth_utils import apply_formatter_to_array
+
+>>> map_int = apply_formatter_to_array(int)
+
+>>> map_int((1.2, 3.4, 5.6))
+[1, 3, 5]
+```
+
+
 #### `combine_argument_formatters(*formatters)` -> lambda <list_like>: list
 
 Combine several formatters to be applied to a list-like value, each formatter

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`
 
 All functions can be imported directly from the `eth_utils` module
 
+Alternatively, you can get the curried version of the functions by importing them
+through the `curried` module like so:
+
+```py
+from eth_utils.curried import apply_formatters_to_dict
+```
 
 ### ABI Utils
 
@@ -138,12 +144,15 @@ def i_put_my_thing_down_flip_it_and_reverse_it(lyric):
     return ''.join(reversed(lyric))
 ```
 
+These tools often work nicely when curried. Import them from the `curried` module to get that
+capability built in, like `from eth_utils.curried import apply_formatter_if`.
+
 #### `apply_formatter_if(condition, formatter, value)` -> new_value
 
-This curry-able function will apply the formatter only if `bool(condition()) is True`.
+This function will apply the formatter only if `bool(condition()) is True`.
 
 ```py
->>> from eth_utils import apply_formatter_if, is_string
+>>> from eth_utils.curried import apply_formatter_if, is_string
 
 >>> bool_if_string = apply_formatter_if(is_string, bool)
 
@@ -158,12 +167,12 @@ False
 
 #### `apply_one_of_formatters(condition_formatter_pairs, value)` -> new_value
 
-This curry-able function will iterate through `condition_formatter_pairs`, and
+This function will iterate through `condition_formatter_pairs`, and
 apply the first formatter which has a truthy condition. One of the formatters
 *must* match, or this function will raise a `ValueError`.
 
 ```py
->>> from eth_utils import apply_one_of_formatters, is_string, is_list_like
+>>> from eth_utils.curried import apply_one_of_formatters, is_string, is_list_like
 
 >>> multi_formatter = apply_one_of_formatters((
     (is_list_like, tuple),
@@ -180,12 +189,12 @@ ValueError("The provided value did not satisfy any of the formatter conditions")
 
 #### `apply_formatter_at_index(formatter, at_index, <list_like>)` -> <new_list_like>
 
-This curry-able function will apply the formatter to one element of `list_like`,
+This function will apply the formatter to one element of `list_like`,
 at position `at_index`, and return a new iterable with that element replaced.
 The returned value will be the same type as the one passed into the third argument.
 
 ```py
->>> from eth_utils import apply_formatter_at_index
+>>> from eth_utils.curried import apply_formatter_at_index
 
 >>> targetted_formatter = apply_formatter_at_index(bool, 1)
 
@@ -199,11 +208,11 @@ The returned value will be the same type as the one passed into the third argume
 
 #### `apply_formatter_to_array(formatter, <list_like>)` -> <new_list_like>
 
-This curry-able function will apply the formatter to each element of `list_like`.
+This function will apply the formatter to each element of `list_like`.
 It returns the same type as the `list_like` argument
 
 ```py
->>> from eth_utils import apply_formatter_to_array
+>>> from eth_utils.curried import apply_formatter_to_array
 
 >>> map_int = apply_formatter_to_array(int)
 
@@ -240,12 +249,12 @@ it was supplied. For example:
 
 #### `apply_formatters_to_dict(formatter_dict, <dict_like>)` -> `dict`
 
-This curry-able function will apply the formatter to the element with
+This function will apply the formatter to the element with
 the matching key in `dict_like`, passing through values with keys that
 have no matching formatter.
 
 ```py
->>> from eth_utils import apply_formatters_to_dict
+>>> from eth_utils.curried import apply_formatters_to_dict
 
 >>> dict_formatter = apply_formatters_to_dict({
     'should_be_int': int,
@@ -267,11 +276,11 @@ have no matching formatter.
 
 #### `apply_key_map(formatter_dict, <dict_like>)` -> `dict`
 
-This curry-able function will rename keys from <dict_like> using the
+This function will rename keys from <dict_like> using the
 lookups provided in `formatter_dict`. It will pass through any unspecified keys.
 
 ```py
->>> from eth_utils import apply_key_map
+>>> from eth_utils.curried import apply_key_map
 
 >>> dict_key_map = apply_key_map({
     'black': 'orange',

--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ The returned value will be the same type as the one passed into the third argume
 ```
 
 
-#### `apply_formatter_to_array(formatter, <list_like>)` -> <new_list>
+#### `apply_formatter_to_array(formatter, <list_like>)` -> <new_list_like>
 
 This curry-able function will apply the formatter to each element of `list_like`.
+It returns the same type as the `list_like` argument
 
 ```py
 >>> from eth_utils import apply_formatter_to_array
@@ -207,6 +208,9 @@ This curry-able function will apply the formatter to each element of `list_like`
 >>> map_int = apply_formatter_to_array(int)
 
 >>> map_int((1.2, 3.4, 5.6))
+(1, 3, 5)
+
+>>> map_int([1.2, 3.4, 5.6])
 [1, 3, 5]
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,42 @@ Returns the 4 byte function selector for the given function signature.
 b'\xc3x\n:'
 ```
 
+### Applicators
+
+Applicators help you apply "formatters" in various ways, most notably:
+
+- apply formatters to values by key
+- apply formatters to lists by index
+- conditionally applying a formatter
+- conditionally applying one of several formatters.
+
+Here we define a "formatter" as any `callable` that may be called with a single positional argument.
+It returns the "formatted" result. For example `int()` could be used as a formatter.
+
+Defining your own formatter is easy:
+
+```py
+def i_put_my_thing_down_flip_it_and_reverse_it(lyric):
+    return ''.join(reversed(lyric))
+```
+
+#### `apply_formatter_if(condition, formatter, value)` -> new_value
+
+This curried function will apply the formatter only if `bool(condition()) is True`.
+
+```py
+>>> from eth_utils import apply_formatter_if, is_string
+
+>>> bool_if_string = apply_formatter_if(is_string, bool)
+
+>>> bool_if_string(1)
+1
+>>> bool_if_string('1')
+True
+>>> bool_if_string('')
+False
+```
+
 
 ### Address Utils
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -25,6 +25,7 @@ from .address import (  # noqa: F401
 from .applicators import (  # noqa: F401
     apply_formatter_at_index,
     apply_formatter_if,
+    apply_formatter_to_array,
     apply_formatters_to_dict,
     apply_one_of_formatters,
     combine_argument_formatters,

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -27,6 +27,7 @@ from .applicators import (  # noqa: F401
     apply_formatter_if,
     apply_formatters_to_dict,
     apply_one_of_formatters,
+    combine_argument_formatters,
 )
 from .conversions import (  # noqa: F401
     to_bytes,

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -22,6 +22,9 @@ from .address import (  # noqa: F401
     to_checksum_address,
     to_normalized_address,
 )
+from .applicators import (  # noqa: F401
+    apply_formatters_to_dict,
+)
 from .conversions import (  # noqa: F401
     to_bytes,
     to_hex,

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -24,6 +24,7 @@ from .address import (  # noqa: F401
 )
 from .applicators import (  # noqa: F401
     apply_formatters_to_dict,
+    apply_formatter_if,
 )
 from .conversions import (  # noqa: F401
     to_bytes,

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -23,8 +23,9 @@ from .address import (  # noqa: F401
     to_normalized_address,
 )
 from .applicators import (  # noqa: F401
-    apply_formatters_to_dict,
+    apply_formatter_at_index,
     apply_formatter_if,
+    apply_formatters_to_dict,
     apply_one_of_formatters,
 )
 from .conversions import (  # noqa: F401

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -25,6 +25,7 @@ from .address import (  # noqa: F401
 from .applicators import (  # noqa: F401
     apply_formatters_to_dict,
     apply_formatter_if,
+    apply_one_of_formatters,
 )
 from .conversions import (  # noqa: F401
     to_bytes,

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -27,6 +27,7 @@ from .applicators import (  # noqa: F401
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
+    apply_key_map,
     apply_one_of_formatters,
     combine_argument_formatters,
 )

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -62,7 +62,7 @@ def apply_formatter_to_array(formatter, value):
 
 @curry
 def apply_one_of_formatters(formatter_condition_pairs, value):
-    for formatter, condition in formatter_condition_pairs:
+    for condition, formatter in formatter_condition_pairs:
         if condition(value):
             return formatter(value)
     else:

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -3,14 +3,16 @@ from cytoolz.functoolz import (
     compose,
 )
 
+from .decorators import (
+    return_arg_type,
+)
 from .functional import (
-    to_list,
     to_dict,
 )
 
 
 @curry
-@to_list
+@return_arg_type(2)
 def apply_formatter_at_index(formatter, at_index, value):
     if at_index + 1 > len(value):
         raise IndexError(

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -24,7 +24,7 @@ def apply_formatter_at_index(formatter, at_index, value):
             yield item
 
 
-def apply_formatters_to_args(*formatters):
+def combine_argument_formatters(*formatters):
     return compose(*(
         apply_formatter_at_index(formatter, index)
         for index, formatter

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,0 +1,79 @@
+from cytoolz.functoolz import (
+    curry,
+    compose,
+)
+
+from .functional import (
+    to_list,
+    to_dict,
+)
+
+
+@curry
+@to_list
+def apply_formatter_at_index(formatter, at_index, value):
+    if at_index + 1 > len(value):
+        raise IndexError(
+            "Not enough values in iterable to apply formatter.  Got: {0}. "
+            "Need: {1}".format(len(value), at_index + 1)
+        )
+    for index, item in enumerate(value):
+        if index == at_index:
+            yield formatter(item)
+        else:
+            yield item
+
+
+def apply_formatters_to_args(*formatters):
+    return compose(*(
+        apply_formatter_at_index(formatter, index)
+        for index, formatter
+        in enumerate(formatters)
+    ))
+
+
+@curry
+def apply_formatter_if(condition, formatter, value):
+    if condition(value):
+        return formatter(value)
+    else:
+        return value
+
+
+@curry
+@to_dict
+def apply_formatters_to_dict(formatters, value):
+    for key, item in value.items():
+        if key in formatters:
+            try:
+                yield key, formatters[key](item)
+            except (TypeError, ValueError) as exc:
+                raise type(exc)("Could not format value %r as field %r" % (item, key)) from exc
+        else:
+            yield key, item
+
+
+@curry
+@to_list
+def apply_formatter_to_array(formatter, value):
+    for item in value:
+        yield formatter(item)
+
+
+@curry
+def apply_one_of_formatters(formatter_condition_pairs, value):
+    for formatter, condition in formatter_condition_pairs:
+        if condition(value):
+            return formatter(value)
+    else:
+        raise ValueError("The provided value did not satisfy any of the formatter conditions")
+
+
+@curry
+@to_dict
+def apply_key_map(key_mappings, value):
+    for key, item in value.items():
+        if key in key_mappings:
+            yield key_mappings[key], item
+        else:
+            yield key, item

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,6 +1,6 @@
 from cytoolz.functoolz import (
-    curry,
     compose,
+    curry,
 )
 
 from .decorators import (
@@ -11,7 +11,6 @@ from .functional import (
 )
 
 
-@curry
 @return_arg_type(2)
 def apply_formatter_at_index(formatter, at_index, value):
     if at_index + 1 > len(value):
@@ -27,14 +26,14 @@ def apply_formatter_at_index(formatter, at_index, value):
 
 
 def combine_argument_formatters(*formatters):
+    _formatter_at_index = curry(apply_formatter_at_index)
     return compose(*(
-        apply_formatter_at_index(formatter, index)
+        _formatter_at_index(formatter, index)
         for index, formatter
         in enumerate(formatters)
     ))
 
 
-@curry
 def apply_formatter_if(condition, formatter, value):
     if condition(value):
         return formatter(value)
@@ -42,7 +41,6 @@ def apply_formatter_if(condition, formatter, value):
         return value
 
 
-@curry
 @to_dict
 def apply_formatters_to_dict(formatters, value):
     for key, item in value.items():
@@ -55,14 +53,12 @@ def apply_formatters_to_dict(formatters, value):
             yield key, item
 
 
-@curry
 @return_arg_type(1)
 def apply_formatter_to_array(formatter, value):
     for item in value:
         yield formatter(item)
 
 
-@curry
 def apply_one_of_formatters(formatter_condition_pairs, value):
     for condition, formatter in formatter_condition_pairs:
         if condition(value):
@@ -71,7 +67,6 @@ def apply_one_of_formatters(formatter_condition_pairs, value):
         raise ValueError("The provided value did not satisfy any of the formatter conditions")
 
 
-@curry
 @to_dict
 def apply_key_map(key_mappings, value):
     for key, item in value.items():

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -56,7 +56,7 @@ def apply_formatters_to_dict(formatters, value):
 
 
 @curry
-@to_list
+@return_arg_type(1)
 def apply_formatter_to_array(formatter, value):
     for item in value:
         yield formatter(item)

--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -1,7 +1,3 @@
-from cytoolz import (
-    curry,
-)
-
 from .decorators import (
     assert_one_arg,
 )
@@ -112,7 +108,6 @@ def to_text(primitive=None, hexstr=None, text=None):
     raise TypeError("Expected an int, bytes or hexstr.")
 
 
-@curry
 def text_if_str(to_type, text_or_primitive):
     '''
     Convert to a type, assuming that strings can be only unicode text (not a hexstr)
@@ -128,7 +123,6 @@ def text_if_str(to_type, text_or_primitive):
     return to_type(primitive, text=text)
 
 
-@curry
 def hexstr_if_str(to_type, hexstr_or_primitive):
     '''
     Convert to a type, assuming that strings can be only hexstr (not unicode text)

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -1,0 +1,95 @@
+from cytoolz import (
+    curry,
+)
+
+from eth_utils import (
+    add_0x_prefix,
+    apply_formatter_at_index,
+    apply_formatter_if,
+    apply_formatter_to_array,
+    apply_formatters_to_dict,
+    apply_key_map,
+    apply_one_of_formatters,
+    apply_to_return_value,
+    big_endian_to_int,
+    coerce_args_to_bytes,
+    coerce_args_to_text,
+    coerce_return_to_bytes,
+    coerce_return_to_text,
+    combine_argument_formatters,
+    combomethod,
+    decode_hex,
+    denoms,
+    encode_hex,
+    event_abi_to_log_topic,
+    event_signature_to_log_topic,
+    flatten_return,
+    force_bytes,
+    force_obj_to_bytes,
+    force_obj_to_text,
+    force_text,
+    from_wei,
+    function_abi_to_4byte_selector,
+    function_signature_to_4byte_selector,
+    hexstr_if_str,
+    int_to_big_endian,
+    is_0x_prefixed,
+    is_32byte_address,
+    is_address,
+    is_binary_address,
+    is_boolean,
+    is_bytes,
+    is_canonical_address,
+    is_checksum_address,
+    is_checksum_formatted_address,
+    is_dict,
+    is_hex,
+    is_hex_address,
+    is_integer,
+    is_list_like,
+    is_normalized_address,
+    is_null,
+    is_number,
+    is_same_address,
+    is_string,
+    is_text,
+    keccak,
+    pad_left,
+    pad_right,
+    remove_0x_prefix,
+    reversed_return,
+    sort_return,
+    text_if_str,
+    to_bytes,
+    to_canonical_address,
+    to_checksum_address,
+    to_dict,
+    to_hex,
+    to_int,
+    to_list,
+    to_normalized_address,
+    to_ordered_dict,
+    to_set,
+    to_text,
+    to_tuple,
+    to_wei,
+)
+
+apply_formatter_at_index = curry(apply_formatter_at_index)
+apply_formatter_if = curry(apply_formatter_if)
+apply_formatter_to_array = curry(apply_formatter_to_array)
+apply_formatters_to_dict = curry(apply_formatters_to_dict)
+apply_key_map = curry(apply_key_map)
+apply_one_of_formatters = curry(apply_one_of_formatters)
+flatten_return = curry(flatten_return)
+force_bytes = curry(force_bytes)
+force_text = curry(force_text)
+from_wei = curry(from_wei)
+is_same_address = curry(is_same_address)
+pad_left = curry(pad_left)
+pad_right = curry(pad_right)
+reversed_return = curry(reversed_return)
+sort_return = curry(sort_return)
+to_wei = curry(to_wei)
+
+del curry

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from cytoolz import (
     curry,
 )
@@ -85,11 +87,13 @@ flatten_return = curry(flatten_return)
 force_bytes = curry(force_bytes)
 force_text = curry(force_text)
 from_wei = curry(from_wei)
+hexstr_if_str = curry(hexstr_if_str)
 is_same_address = curry(is_same_address)
 pad_left = curry(pad_left)
 pad_right = curry(pad_right)
 reversed_return = curry(reversed_return)
 sort_return = curry(sort_return)
+text_if_str = curry(text_if_str)
 to_wei = curry(to_wei)
 
 del curry

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -1,6 +1,10 @@
 import functools
 import itertools
 
+from cytoolz import (
+    identity,
+)
+
 
 class combomethod(object):
     def __init__(self, method):
@@ -36,3 +40,20 @@ def assert_one_arg(to_wrap):
         _assert_one_val(*args, **kwargs)
         return to_wrap(*args, **kwargs)
     return wrapper
+
+
+def return_arg_type(at_position):
+    '''
+    Wrap the return value with the result of `type(args[at_position])`
+    '''
+    def decorator(to_wrap):
+        @functools.wraps(to_wrap)
+        def wrapper(*args, **kwargs):
+            try:
+                ReturnType = type(args[at_position])
+            except IndexError:
+                ReturnType = identity
+            result = to_wrap(*args, **kwargs)
+            return ReturnType(result)
+        return wrapper
+    return decorator

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -1,6 +1,7 @@
 import pytest
 
 from eth_utils import (
+    apply_formatter_at_index,
     apply_formatter_if,
     apply_formatters_to_dict,
     apply_one_of_formatters,
@@ -62,3 +63,22 @@ def test_apply_one_of_formatters(condition_formatters, value, expected):
         # must be able to curry
         apply_one = apply_one_of_formatters(condition_formatters)
         assert apply_one(value) == expected
+
+
+@pytest.mark.parametrize(
+    'formatter, index, value, expected',
+    (
+        (bool, 1, (1, 2, 3), [1, True, 3]),
+        (bool, 3, (1, 2, 3), IndexError),
+    ),
+)
+def test_apply_formatter_at_index(formatter, index, value, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            apply_formatter_at_index(formatter, index, value)
+    else:
+        assert apply_formatter_at_index(formatter, index, value) == expected
+
+        # must be able to curry
+        targetted_formatter = apply_formatter_at_index(formatter, index)
+        assert targetted_formatter(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -5,6 +5,7 @@ from eth_utils import (
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
+    apply_key_map,
     apply_one_of_formatters,
     combine_argument_formatters,
     is_list_like,
@@ -47,6 +48,22 @@ def test_apply_formatters_to_dict(formatter, value, expected):
     mapper = apply_formatters_to_dict(formatter)
     assert mapper(value) == expected
 
+
+@pytest.mark.parametrize(
+    'formatter, value, expected',
+    (
+        (
+            {'black': 'orange', 'Internet': 'Ethereum'},
+            {'black': 1.2, 'Internet': 3.4, 'pass_through': 5.6},
+            {'orange': 1.2, 'Ethereum': 3.4, 'pass_through': 5.6},
+        ),
+    ),
+)
+def test_apply_key_map(formatter, value, expected):
+    assert apply_key_map(formatter, value) == expected
+
+    mapper = apply_key_map(formatter)
+    assert mapper(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -102,7 +119,6 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
         # must be able to curry
         targetted_formatter = apply_formatter_at_index(formatter, index)
         assert targetted_formatter(value) == expected
-
 
 
 @pytest.mark.parametrize(

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -105,7 +105,8 @@ def test_apply_one_of_formatters(condition_formatters, value, expected):
 @pytest.mark.parametrize(
     'formatter, index, value, expected',
     (
-        (bool, 1, (1, 2, 3), [1, True, 3]),
+        (bool, 1, [1, 2, 3], [1, True, 3]),
+        (bool, 1, (1, 2, 3), (1, True, 3)),
         (bool, 3, (1, 2, 3), IndexError),
     ),
 )

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -1,0 +1,14 @@
+import pytest
+
+from eth_utils import (
+    apply_formatters_to_dict,
+)
+
+
+def test_format_dict_error():
+    with pytest.raises(ValueError) as exc_info:
+        apply_formatters_to_dict(
+            {'myfield': int},
+            {'myfield': 'a'},
+        )
+    assert 'myfield' in str(exc_info.value)

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -1,13 +1,14 @@
 import pytest
 
-from eth_utils import (
+import eth_utils
+
+from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
     apply_key_map,
     apply_one_of_formatters,
-    combine_argument_formatters,
     is_list_like,
     is_string,
 )
@@ -29,6 +30,11 @@ def test_format_dict_error():
             {'myfield': int},
             {'myfield': 'a'},
         )
+    with pytest.raises(ValueError) as exc_info:
+        eth_utils.apply_formatters_to_dict(
+            {'myfield': int},
+            {'myfield': 'a'},
+        )
     assert 'myfield' in str(exc_info.value)
 
 
@@ -43,7 +49,7 @@ def test_format_dict_error():
     ),
 )
 def test_apply_formatters_to_dict(formatter, value, expected):
-    assert apply_formatters_to_dict(formatter, value) == expected
+    assert eth_utils.apply_formatters_to_dict(formatter, value) == expected
 
     mapper = apply_formatters_to_dict(formatter)
     assert mapper(value) == expected
@@ -60,7 +66,7 @@ def test_apply_formatters_to_dict(formatter, value, expected):
     ),
 )
 def test_apply_key_map(formatter, value, expected):
-    assert apply_key_map(formatter, value) == expected
+    assert eth_utils.apply_key_map(formatter, value) == expected
 
     mapper = apply_key_map(formatter)
     assert mapper(value) == expected
@@ -75,7 +81,7 @@ def test_apply_key_map(formatter, value, expected):
     ),
 )
 def test_apply_formatter_if(condition, formatter, value, expected):
-    assert apply_formatter_if(condition, formatter, value) == expected
+    assert eth_utils.apply_formatter_if(condition, formatter, value) == expected
 
     # must be able to curry
     conditional_formatter = apply_formatter_if(condition, formatter)
@@ -94,8 +100,10 @@ def test_apply_one_of_formatters(condition_formatters, value, expected):
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
             apply_one_of_formatters(condition_formatters, value)
+        with pytest.raises(expected):
+            eth_utils.apply_one_of_formatters(condition_formatters, value)
     else:
-        assert apply_one_of_formatters(condition_formatters, value) == expected
+        assert eth_utils.apply_one_of_formatters(condition_formatters, value) == expected
 
         # must be able to curry
         apply_one = apply_one_of_formatters(condition_formatters)
@@ -114,8 +122,10 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
             apply_formatter_at_index(formatter, index, value)
+        with pytest.raises(expected):
+            eth_utils.apply_formatter_at_index(formatter, index, value)
     else:
-        assert apply_formatter_at_index(formatter, index, value) == expected
+        assert eth_utils.apply_formatter_at_index(formatter, index, value) == expected
 
         # must be able to curry
         targetted_formatter = apply_formatter_at_index(formatter, index)
@@ -148,7 +158,7 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
     ),
 )
 def test_combine_argument_formatters(formatters, value, expected):
-    list_formatter = combine_argument_formatters(*formatters)
+    list_formatter = eth_utils.combine_argument_formatters(*formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
             list_formatter(value)
@@ -172,7 +182,7 @@ def test_combine_argument_formatters(formatters, value, expected):
     ),
 )
 def test_apply_formatter_to_array(formatter, value, expected):
-    assert apply_formatter_to_array(formatter, value) == expected
+    assert eth_utils.apply_formatter_to_array(formatter, value) == expected
 
     mapper = apply_formatter_to_array(formatter)
     assert mapper(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -3,7 +3,19 @@ import pytest
 from eth_utils import (
     apply_formatter_if,
     apply_formatters_to_dict,
+    apply_one_of_formatters,
+    is_list_like,
     is_string,
+)
+
+
+def i_put_my_thing_down_flip_it_and_reverse_it(lyric):
+    return ''.join(reversed(lyric))
+
+
+CONDITION_FORMATTER_PAIRS = (
+    (is_list_like, tuple),
+    (is_string, i_put_my_thing_down_flip_it_and_reverse_it),
 )
 
 
@@ -30,3 +42,23 @@ def test_apply_formatter_if(condition, formatter, value, expected):
     # must be able to curry
     conditional_formatter = apply_formatter_if(condition, formatter)
     assert conditional_formatter(value) == expected
+
+
+@pytest.mark.parametrize(
+    'condition_formatters, value, expected',
+    (
+        (CONDITION_FORMATTER_PAIRS, 'my thing', 'gniht ym'),
+        (CONDITION_FORMATTER_PAIRS, [2, 3], (2, 3)),
+        (CONDITION_FORMATTER_PAIRS, 1, ValueError),
+    ),
+)
+def test_apply_one_of_formatters(condition_formatters, value, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            apply_one_of_formatters(condition_formatters, value)
+    else:
+        assert apply_one_of_formatters(condition_formatters, value) == expected
+
+        # must be able to curry
+        apply_one = apply_one_of_formatters(condition_formatters)
+        assert apply_one(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -161,8 +161,13 @@ def test_combine_argument_formatters(formatters, value, expected):
     (
         (
             int,
-            (1.2, 3.4, 5.6),
+            [1.2, 3.4, 5.6],
             [1, 3, 5],
+        ),
+        (
+            int,
+            (1.2, 3.4, 5.6),
+            (1, 3, 5),
         ),
     ),
 )

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -5,6 +5,7 @@ from eth_utils import (
     apply_formatter_if,
     apply_formatters_to_dict,
     apply_one_of_formatters,
+    combine_argument_formatters,
     is_list_like,
     is_string,
 )
@@ -82,3 +83,33 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
         # must be able to curry
         targetted_formatter = apply_formatter_at_index(formatter, index)
         assert targetted_formatter(value) == expected
+
+
+
+@pytest.mark.parametrize(
+    'formatters, value, expected',
+    (
+        (
+            [bool, int, str],
+            (1.2, 3.4, 5.6),
+            [True, 3, '5.6'],
+        ),
+        (
+            [bool, int],
+            (1.2, 3.4, 5.6),
+            [True, 3, 5.6],
+        ),
+        (
+            [bool, int, str, float],
+            (1.2, 3.4, 5.6),
+            IndexError,
+        ),
+    ),
+)
+def test_combine_argument_formatters(formatters, value, expected):
+    list_formatter = combine_argument_formatters(*formatters)
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            list_formatter(value)
+    else:
+        assert list_formatter(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -1,7 +1,9 @@
 import pytest
 
 from eth_utils import (
+    apply_formatter_if,
     apply_formatters_to_dict,
+    is_string,
 )
 
 
@@ -12,3 +14,19 @@ def test_format_dict_error():
             {'myfield': 'a'},
         )
     assert 'myfield' in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'condition, formatter, value, expected',
+    (
+        (is_string, bool, 1, 1),
+        (is_string, bool, '1', True),
+        (is_string, bool, '', False),
+    ),
+)
+def test_apply_formatter_if(condition, formatter, value, expected):
+    assert apply_formatter_if(condition, formatter, value) == expected
+
+    # must be able to curry
+    conditional_formatter = apply_formatter_if(condition, formatter)
+    assert conditional_formatter(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -128,11 +128,16 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
         (
             [bool, int, str],
             (1.2, 3.4, 5.6),
-            [True, 3, '5.6'],
+            (True, 3, '5.6'),
         ),
         (
             [bool, int],
             (1.2, 3.4, 5.6),
+            (True, 3, 5.6),
+        ),
+        (
+            [bool, int],
+            [1.2, 3.4, 5.6],
             [True, 3, 5.6],
         ),
         (

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -3,6 +3,7 @@ import pytest
 from eth_utils import (
     apply_formatter_at_index,
     apply_formatter_if,
+    apply_formatter_to_array,
     apply_formatters_to_dict,
     apply_one_of_formatters,
     combine_argument_formatters,
@@ -113,3 +114,20 @@ def test_combine_argument_formatters(formatters, value, expected):
             list_formatter(value)
     else:
         assert list_formatter(value) == expected
+
+
+@pytest.mark.parametrize(
+    'formatter, value, expected',
+    (
+        (
+            int,
+            (1.2, 3.4, 5.6),
+            [1, 3, 5],
+        ),
+    ),
+)
+def test_apply_formatter_to_array(formatter, value, expected):
+    assert apply_formatter_to_array(formatter, value) == expected
+
+    mapper = apply_formatter_to_array(formatter)
+    assert mapper(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -32,6 +32,24 @@ def test_format_dict_error():
 
 
 @pytest.mark.parametrize(
+    'formatter, value, expected',
+    (
+        (
+            {'should_be_int': int, 'should_be_bool': bool},
+            {'should_be_int': 1.2, 'should_be_bool': 3.4, 'pass_through': 5.6},
+            {'should_be_int': 1, 'should_be_bool': True, 'pass_through': 5.6},
+        ),
+    ),
+)
+def test_apply_formatters_to_dict(formatter, value, expected):
+    assert apply_formatters_to_dict(formatter, value) == expected
+
+    mapper = apply_formatters_to_dict(formatter)
+    assert mapper(value) == expected
+
+
+
+@pytest.mark.parametrize(
     'condition, formatter, value, expected',
     (
         (is_string, bool, 1, 1),

--- a/tests/curried-utils/test_curried.py
+++ b/tests/curried-utils/test_curried.py
@@ -1,0 +1,78 @@
+from cytoolz import (
+    curry,
+    keyfilter,
+    merge_with,
+    valfilter,
+)
+from cytoolz.functoolz import (
+    has_keywords,
+    num_required_args,
+)
+
+import eth_utils
+import eth_utils.curried
+
+
+# heavily inspired by https://github.com/pytoolz/toolz/blob/20d8aefc0a5/toolz/tests/test_curried.py
+def test_curried_namespace():
+    namespace = {}
+
+    def should_curry(func):
+        if not callable(func) or isinstance(func, curry):
+            return False
+        nargs = num_required_args(func)
+        if nargs is None or nargs > 1:
+            return True
+        else:
+            return nargs == 1 and has_keywords(func)
+
+
+    def curry_namespace(ns):
+        return dict(
+            (
+                name,
+                curry(f) if should_curry(f) else f,
+            )
+            for name, f in ns.items()
+            if '__' not in name
+        )
+
+    all_auto_curried = curry_namespace(vars(eth_utils))
+
+    inferred_namespace = valfilter(callable, all_auto_curried)
+    curried_namespace = valfilter(callable, eth_utils.curried.__dict__)
+
+    if inferred_namespace != curried_namespace:
+        missing = set(inferred_namespace) - set(curried_namespace)
+        if missing:
+            to_insert = sorted("%s," % f for f in missing)
+            raise AssertionError(
+                'There are missing functions in eth_utils.curried:\n'
+                + '\n'.join(to_insert)
+            )
+        extra = set(curried_namespace) - set(inferred_namespace)
+        if extra:
+            raise AssertionError(
+                'There are extra functions in eth_utils.curried:\n'
+                + '\n'.join(sorted(extra))
+            )
+        unequal = merge_with(list, inferred_namespace, curried_namespace)
+        unequal = valfilter(lambda x: x[0] != x[1], unequal)
+        to_curry = keyfilter(lambda x: should_curry(getattr(eth_utils, x)), unequal)
+        if to_curry:
+            to_curry_formatted = sorted('{0} = curry({0})'.format(f) for f in to_curry)
+            raise AssertionError(
+                'There are missing functions to curry in eth_utils.curried:\n'
+                + '\n'.join(to_curry_formatted)
+            )
+        elif unequal:
+            not_to_curry_formatted = sorted(unequal)
+            raise AssertionError(
+                'Missing functions NOT to curry in eth_utils.curried:\n'
+                + '\n'.join(not_to_curry_formatted)
+            )
+        else:
+            raise AssertionError("unexplained difference between %r and %r" % (
+                inferred_namespace,
+                curried_namespace,
+            ))


### PR DESCRIPTION
### What was wrong?

Wanted to use apply_formatters_to_dict in eth-account

### How was it fixed?

Imported it, added doc and test. Then got carried away and imported many of the others, because it seems like they belong in the same place.

Notable changes proposed (in code) during the import:

- Reversed the order of the condition & formatter in `apply_one_of_formatters` to match the new order of `apply_formatter_if(condition, formatter)`
- Rename `apply_formatters_to_args` -> `combine_argument_formatters` because it's the only one that doesn't actually apply when you supply all the arguments.

#### Cute Animal Picture

![Cute animal picture](http://www.pbh2.com/wordpress/wp-content/uploads/2013/04/cutest-baby-animals-gifs-pitbull.gif)
