### PR TITLE
WIP - Convert `force_bytes`// `force_text` functions to new `to_text` // `to_bytes`

### DIFF
--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -9,13 +9,6 @@ from .encoding import (
     big_endian_to_int,
     int_to_big_endian,
 )
-from .hexidecimal import (
-    add_0x_prefix,
-    decode_hex,
-    encode_hex,
-    is_hex,
-    remove_0x_prefix,
-)
 from .types import (
     is_boolean,
     is_integer,
@@ -31,6 +24,10 @@ def to_hex(value=None, hexstr=None, text=None):
     Trims leading zeros, as defined in:
     https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
     """
+    from .hexidecimal import (
+        add_0x_prefix,
+        encode_hex,
+    )
     if hexstr is not None:
         return add_0x_prefix(hexstr.lower())
 
@@ -81,6 +78,10 @@ def to_int(value=None, hexstr=None, text=None):
 
 @assert_one_arg
 def to_bytes(primitive=None, hexstr=None, text=None):
+    from .hexidecimal import (
+        remove_0x_prefix,
+        decode_hex,
+    )
     if is_boolean(primitive):
         return b'\x01' if primitive else b'\x00'
     elif isinstance(primitive, bytes):
@@ -137,6 +138,10 @@ def hexstr_if_str(to_type, hexstr_or_primitive):
         eg~ to_bytes, to_text, to_hex, to_int, etc
     @param text_or_primitive in bytes, str, or int.
     '''
+    from .hexidecimal import (
+        remove_0x_prefix,
+        is_hex,
+    )
     if isinstance(hexstr_or_primitive, str):
         (primitive, hexstr) = (None, hexstr_or_primitive)
         if remove_0x_prefix(hexstr) and not is_hex(hexstr):

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -3,13 +3,13 @@ try:
 except ImportError:
     from sha3 import sha3_256 as keccak_256
 
-from .string import (
-    force_bytes,
+from .conversions import (
+    to_bytes,
 )
 
 
 def keccak(value):
-    return keccak_256(force_bytes(value)).digest()
+    return keccak_256(to_bytes(text=value)).digest()
 
 
 # ensure we have the *correct* hash function

--- a/eth_utils/formatting.py
+++ b/eth_utils/formatting.py
@@ -1,6 +1,6 @@
-from .string import (
-    force_bytes,
-    force_text,
+from .conversions import (
+    to_text,
+    to_bytes,
 )
 from .types import (
     is_bytes,
@@ -13,7 +13,9 @@ def pad_left(value, to_size, pad_with):
     """
     pad_amount = to_size - len(value)
     head = b"" if is_bytes(value) else ""
-    pad_with_value = force_bytes(pad_with) if is_bytes(value) else force_text(pad_with)
+    pad_args = {'primitive': pad_with} if is_bytes(pad_with) else {'text': pad_with}
+    pad_value = to_bytes(**pad_args) if is_bytes(value) else to_text(**pad_args)
+    pad_with_value = to_text(text=pad_value)
     if pad_amount > 0:
         head = pad_with_value * (pad_amount // len(pad_with_value))
         head += pad_with_value[:(pad_amount % len(pad_with_value))]
@@ -26,7 +28,9 @@ def pad_right(value, to_size, pad_with):
     """
     pad_amount = to_size - len(value)
     tail = b"" if is_bytes(value) else ""
-    pad_with_value = force_bytes(pad_with) if is_bytes(value) else force_text(pad_with)
+    pad_args = {'primitive': pad_with} if is_bytes(pad_with) else {'text': pad_with}
+    pad_value = to_bytes(**pad_args) if is_bytes(value) else to_text(**pad_args)
+    pad_with_value = to_text(text=pad_value)
     if pad_amount > 0:
         tail = pad_with_value * (pad_amount // len(pad_with_value))
         tail += pad_with_value[:(pad_amount % len(pad_with_value))]
@@ -34,6 +38,6 @@ def pad_right(value, to_size, pad_with):
 
 
 def is_prefixed(value, prefix):
-    return value.startswith(
-        force_bytes(prefix) if is_bytes(value) else force_text(prefix)
-    )
+    prefix_args = {'primitive': prefix} if is_bytes(prefix) else {'text': prefix}
+    prefix_value = to_bytes(**prefix_args) if is_bytes(value) else to_text(**prefix_args)
+    return value.startswith(prefix_value)

--- a/eth_utils/hexidecimal.py
+++ b/eth_utils/hexidecimal.py
@@ -2,36 +2,41 @@
 
 import binascii
 import codecs
-import string
 
 from .types import (
-    is_string,
     is_bytes,
+    is_string,
 )
-from .string import (
-    coerce_args_to_bytes,
-    coerce_return_to_text,
-    coerce_return_to_bytes,
-    force_obj_to_text,
+from .conversions import (
+    to_bytes,
+    to_text,
 )
 from .formatting import (
     is_prefixed,
 )
 
 
-@coerce_return_to_bytes
 def decode_hex(value):
+    """
+    Returns `value` decoded into a byte string.
+    Accepts any string with or without the `0x` prefix.
+    """
     if not is_string(value):
         raise TypeError('Value must be an instance of str or unicode')
-    return codecs.decode(remove_0x_prefix(value), 'hex')
+    decoded = codecs.decode(remove_0x_prefix(value), 'hex')
+    return to_bytes(primitive=decoded)
 
 
-@coerce_args_to_bytes
-@coerce_return_to_text
-def encode_hex(value):
+def encode_hex(primitive=None, hexstr=None, text=None):
+    """
+    Returns any supported value encoded into a hexidecimal representation
+    with a `0x` prefix.
+    """
+    value = to_bytes(primitive, hexstr, text)
     if not is_string(value):
         raise TypeError('Value must be an instance of str or unicode')
-    return add_0x_prefix(codecs.encode(value, 'hex'))
+    encoded = add_0x_prefix(codecs.encode(value, 'hex'))
+    return to_text(primitive=encoded)
 
 
 def is_0x_prefixed(value):
@@ -63,9 +68,6 @@ def is_hex(value):
         value_to_decode = (b'0' if is_bytes(unprefixed_value) else '0') + unprefixed_value
     else:
         value_to_decode = unprefixed_value
-
-    if any(char not in string.hexdigits for char in force_obj_to_text(value_to_decode)):
-        return False
 
     try:
         value_as_bytes = codecs.decode(value_to_decode, 'hex')

--- a/eth_utils/string.py
+++ b/eth_utils/string.py
@@ -1,15 +1,32 @@
-import functools
 import codecs
+import functools
+import warnings
 
 from .types import (
     is_bytes,
-    is_text,
-    is_string,
     is_dict,
     is_list_like,
+    is_string,
+    is_text,
 )
 
 
+def _deprecated(fn):
+    def inner(*args, **kwargs):
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(DeprecationWarning(
+            "The `{0}` function has been deprecated and will be removed in a "
+            "subsequent release of the eth-utils library. UTF8 cannot encode "
+            "some byte values in the 0-255 range which makes naive coersion between "
+            "bytes and text representations impossible without explicitly "
+            "declared encodings.".format(fn.__name__)
+        ))
+        warnings.resetwarnings()
+        return fn(*args, **kwargs)
+    return inner
+
+
+@_deprecated
 def force_bytes(value, encoding='iso-8859-1'):
     if is_bytes(value):
         return bytes(value)
@@ -19,6 +36,7 @@ def force_bytes(value, encoding='iso-8859-1'):
         raise TypeError("Unsupported type: {0}".format(type(value)))
 
 
+@_deprecated
 def force_text(value, encoding='iso-8859-1'):
     if is_text(value):
         return value
@@ -28,6 +46,7 @@ def force_text(value, encoding='iso-8859-1'):
         raise TypeError("Unsupported type: {0}".format(type(value)))
 
 
+@_deprecated
 def force_obj_to_bytes(obj):
     if is_string(obj):
         return force_bytes(obj)
@@ -41,7 +60,11 @@ def force_obj_to_bytes(obj):
         return obj
 
 
+@_deprecated
 def force_obj_to_text(obj):
+    """
+    Returns `obj` with all string elements converted to text strings.
+    """
     if is_string(obj):
         return force_text(obj)
     elif is_dict(obj):
@@ -54,6 +77,7 @@ def force_obj_to_text(obj):
         return obj
 
 
+@_deprecated
 def coerce_args_to_bytes(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -63,6 +87,7 @@ def coerce_args_to_bytes(fn):
     return inner
 
 
+@_deprecated
 def coerce_args_to_text(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -72,6 +97,7 @@ def coerce_args_to_text(fn):
     return inner
 
 
+@_deprecated
 def coerce_return_to_bytes(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
@@ -79,6 +105,7 @@ def coerce_return_to_bytes(fn):
     return inner
 
 
+@_deprecated
 def coerce_return_to_text(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):

--- a/tests/address-utils/test_address_utils.py
+++ b/tests/address-utils/test_address_utils.py
@@ -2,228 +2,304 @@ import pytest
 
 from eth_utils.address import (
     is_address,
-    is_hex_address,
     is_binary_address,
-    is_32byte_address,
-    to_normalized_address,
-    to_canonical_address,
-    is_normalized_address,
     is_canonical_address,
     is_checksum_address,
     is_checksum_formatted_address,
-    to_checksum_address,
+    is_hex_address,
+    is_normalized_address,
     is_same_address,
+    is_32byte_address,
+    to_canonical_address,
+    to_checksum_address,
+    to_normalized_address,
 )
 
 
 @pytest.mark.parametrize(
-    "value,is_any_address,is_hex,is_binary,is_32byte",
-    [
-        (lambda: None, False, False, False, False),
-        ("function", False, False, False, False),
-        ({}, False, False, False, False),
-        # null address
-        ("0x0000000000000000000000000000000000000000", True, True, False, False),
-        # normalized
-        ("0xc6d9d2cd449a754c494264e1809c50e34d64562b", True, True, False, False),
-        # normalized (unprefixed)
-        ("c6d9d2cd449a754c494264e1809c50e34d64562b", True, True, False, False),
-        # checksummed
-        ("0x5B2063246F2191f18F2675ceDB8b28102e957458", True, True, False, False),   # valid
-        ("0x5b2063246F2191f18F2675ceDB8b28102e957458", False, True, False, False),  # invalid
-        # malformed hex
-        ("c6d9d2cd449a754c494264e1809c50e34d64562", False, False, False, False),  # too short
-        ("0xc6d9d2cd449a754c494264e1809c50e34d64562", False, False, False, False),
-        ("c6d9d2cd449a754c494264e1809c50e34d64562bb", False, False, False, False),  # too long
-        ("0xc6d9d2cd449a754c494264e1809c50e34d64562bb", False, False, False, False),
-        ("c6d9d2cd449a754c494264e1809c50e34d64562x", False, False, False, False),  # non-hex-character
-        ("0xc6d9d2cd449a754c494264e1809c50e34d6456x", False, False, False, False),
-        # padded hex
-        ("0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9", True, False, False, True),
-        # binary (TODO)
-        (b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', True, False, True, False),
-        (b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', True, False, False, True),
-        # null 30 bytes
-        ('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', False, False, False, False),
-        ('0x0000000000000000000000000000000000000000000000000000000000000000', False, False, False, False),
-    ]
+    "args,is_any,is_hex,is_binary,is_32byte",
+    (
+        ({'primitive': b'function'}, False, False, False, False),
+        ({'primitive': b'0x0000000000000000000000000000000000000000'}, True, True, False, False), # null address
+        ({'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'}, True, True, False, False), # normalized
+        ({'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562b'}, True, True, False, False), # normalized - unprefixed
+        ({'primitive': b'0x5B2063246F2191f18F2675ceDB8b28102e957458'}, True, True, False, False), # checksummed - valid
+        ({'primitive': b'0x5b2063246F2191f18F2675ceDB8b28102e957458'}, False, True, False, False), # checksummed - invalid
+        ({'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562'}, False, False, False, False), # too short - unprefixed
+        ({'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562'}, False, False, False, False), # too short
+        ({'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562bc'}, False, False, False, False), # too long
+        ({'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562bc'}, False, False, False, False), # too long - unprefixed
+        ({'primitive': b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'}, True, False, False, True), # padded hex
+        ({'primitive': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'}, False, False, False, False), # null 30 bytes
+        ({'primitive': b'0x0000000000000000000000000000000000000000000000000000000000000000'}, False, False, False, False),
+        ({'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'}, True, True, False, False),
+        ({'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562'}, False, False, False, False), # too short
+        ({'hexstr': '66756e6374696f6e'}, False, False, False, False),
+        ({'hexstr': '307830303030303030303030303030303030303030303030303030303030303030303030303030303030'}, True, True, False, False), # null address
+        ({'hexstr': '307863366439643263643434396137353463343934323634653138303963353065333464363435363262'}, True, True, False, False), # normalized
+        ({'text': 'function'}, False, False, False, False),
+        ({'text': '0x0000000000000000000000000000000000000000'}, True, True, False, False), # null address
+        ({'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'}, True, True, False, False), # normalized
+        ({'text': 'c6d9d2cd449a754c494264e1809c50e34d64562b'}, True, True, False, False), # normalized - unprefixed
+        ({'text': '0x5B2063246F2191f18F2675ceDB8b28102e957458'}, True, True, False, False), # checksummed - valid
+        ({'text': '0x5b2063246F2191f18F2675ceDB8b28102e957458'}, False, True, False, False), # checksummed - invalid
+        ({'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562'}, False, False, False, False), # too short
+        ({'text': 'c6d9d2cd449a754c494264e1809c50e34d64562'}, False, False, False, False), # too short - unprefixed
+        ({'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562bc'}, False, False, False, False), # too long
+        ({'text': 'c6d9d2cd449a754c494264e1809c50e34d64562bc'}, False, False, False, False), # too long - unprefixed
+        ({'text': '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'}, True, False, False, True), # padded hex
+        ({'text': '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'}, False, False, False, False), # null 30 bytes
+        ({'text': '0x0000000000000000000000000000000000000000000000000000000000000000'}, False, False, False, False),
+        ({'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'}, True, True, False, False),
+        ({'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562'}, False, False, False, False), # too short
+    )
 )
-def test_is_address(value, is_any_address, is_hex, is_binary, is_32byte):
-    assert is_address(value) is is_any_address
-    assert is_hex_address(value) is is_hex
-    assert is_binary_address(value) is is_binary
-    assert is_32byte_address(value) is is_32byte
+def test_is_address(args, is_any, is_hex, is_binary, is_32byte):
+    assert is_address(**args) == is_any
+    assert is_hex_address(**args) == is_hex
+    assert is_binary_address(**args) == is_binary
+    assert is_32byte_address(**args) == is_32byte
 
 
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ('0x52908400098527886E0F7030069857D2E4169EE7', True),
-        ('0x8617E340B3D01FA5F11F306F4090FD50E238070D', True),
-        ('0xde709f2102306220921060314715629080e2fb77', True),
-        ('0x27b1fdb04752bbc536007a920d24acb045561c26', True),
-        ('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', True),
-        ('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', True),
-        ('0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB', True),
-        ('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb', True),
-        ('0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB', False),
-        ('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', False)
+        ({'primitive': b'0x52908400098527886E0F7030069857D2E4169EE7'}, True),
+        ({'primitive': b'0x8617E340B3D01FA5F11F306F4090FD50E238070D'}, True),
+        ({'primitive': b'0xde709f2102306220921060314715629080e2fb77'}, True),
+        ({'primitive': b'0x27b1fdb04752bbc536007a920d24acb045561c26'}, True),
+        ({'primitive': b'0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'}, True),
+        ({'primitive': b'0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'}, True),
+        ({'primitive': b'0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB'}, True),
+        ({'primitive': b'0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'}, True),
+        ({'primitive': b'0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB'}, False),
+        ({'primitive': b'0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb'}, False),
+        ({'hexstr': '305844313232304130434634374337423942453741324536424138394634323937363245374239414442'}, False),
+        ({'hexstr': '307864313232306130636634376337623962653761326536626138396634323937363265376239616462'}, False),
+        ({'hexstr': '307835323930383430303039383532373838364530463730333030363938353744324534313639454537'}, True),
+        ({'hexstr': '307866423639313630393563613164663630624237394365393263453345613734633337633564333539'}, True),
+        ({'text': '0x52908400098527886E0F7030069857D2E4169EE7'}, True),
+        ({'text': '0x8617E340B3D01FA5F11F306F4090FD50E238070D'}, True),
+        ({'text': '0xde709f2102306220921060314715629080e2fb77'}, True),
+        ({'text': '0x27b1fdb04752bbc536007a920d24acb045561c26'}, True),
+        ({'text': '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'}, True),
+        ({'text': '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'}, True),
+        ({'text': '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB'}, True),
+        ({'text': '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'}, True),
+        ({'text': '0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB'}, False),
+        ({'text': '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb'}, False),
     ]
 )
 def test_is_checksum_address(value, expected):
-    assert is_checksum_address(value) is expected
+    assert is_checksum_address(**value) is expected
 
 
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ('0x52908400098527886E0F7030069857D2E4169EE7', False),
-        ('0x8617E340B3D01FA5F11F306F4090FD50E238070D', False),
-        ('0xde709f2102306220921060314715629080e2fb77', False),
-        ('0x27b1fdb04752bbc536007a920d24acb045561c26', False),
-        ('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', True),
-        ('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', True),
-        ('0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB', True),
-        ('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb', True),
-        ('0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB', False),
-        ('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', False)
+        ({'primitive': b'0x52908400098527886E0F7030069857D2E4169EE7'}, False),
+        ({'primitive': b'0x8617E340B3D01FA5F11F306F4090FD50E238070D'}, False),
+        ({'primitive': b'0xde709f2102306220921060314715629080e2fb77'}, False),
+        ({'primitive': b'0x27b1fdb04752bbc536007a920d24acb045561c26'}, False),
+        ({'primitive': b'0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'}, True),
+        ({'primitive': b'0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'}, True),
+        ({'primitive': b'0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB'}, True),
+        ({'primitive': b'0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'}, True),
+        ({'primitive': b'0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB'}, False),
+        ({'primitive': b'0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb'}, False),
+        ({'hexstr': '307866423639313630393563613164663630624237394365393263453345613734633337633564333539'}, True),
+        ({'hexstr': '307864624630334234303763303145376344334342656139393530396439336638444444433843364642'}, True),
+        ({'hexstr': '307844313232304130636634376337423942653741324536424138394634323937363265376239614462'}, True),
+        ({'hexstr': '305844313232304130434634374337423942453741324536424138394634323937363245374239414442'}, False),
+        ({'hexstr': '307864313232306130636634376337623962653761326536626138396634323937363265376239616462'}, False),
+        ({'text': '0x52908400098527886E0F7030069857D2E4169EE7'}, False),
+        ({'text': '0x8617E340B3D01FA5F11F306F4090FD50E238070D'}, False),
+        ({'text': '0xde709f2102306220921060314715629080e2fb77'}, False),
+        ({'text': '0x27b1fdb04752bbc536007a920d24acb045561c26'}, False),
+        ({'text': '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'}, True),
+        ({'text': '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'}, True),
+        ({'text': '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB'}, True),
+        ({'text': '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'}, True),
+        ({'text': '0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB'}, False),
+        ({'text': '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb'}, False),
     ]
 )
 def test_is_checksum_formatted_address(value, expected):
-    assert is_checksum_formatted_address(value) is expected
+    assert is_checksum_formatted_address(**value) is expected
 
 
 @pytest.mark.parametrize(
     "value,expected",
     [
-        # weird values
-        (lambda: None, False),
-        ("function", False),
-        ({}, False),
-        #
-        ('0xc6d9d2cd449a754c494264e1809c50e34d64562b', True),
-        # non prefixed
-        ('c6d9d2cd449a754c494264e1809c50e34d64562b', False)
+        ({'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'}, False),
+        ({'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562b'}, False),
+        ({'primitive': b'0xd3cda913deb6f67967b99d67acdfa1712c293601'}, False),
+        ({'hexstr': '307863366439643263643434396137353463343934323634653138303963353065333464363435363262'}, False),
+        ({'hexstr': '63366439643263643434396137353463343934323634653138303963353065333464363435363262'}, False),
+        ({'hexstr': '307864336364613931336465623666363739363762393964363761636466613137313263323933363031'}, False),
+        ({'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'}, True),
+        ({'text': 'c6d9d2cd449a754c494264e1809c50e34d64562b'}, False),
+        ({'text': '0xd3cda913deb6f67967b99d67acdfa1712c293601'}, True),
+        ({'text': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'}, False),
+        ({'text': '0xD3CDA913DEB6F67967B99D67ACDFA1712C293601'}, False),
+        ({'text': '0xde709f2102306220921060314715629080e2fb77'}, True),
     ]
 )
 def test_is_normalized_address(value, expected):
-    assert is_normalized_address(value) is expected
+    assert is_normalized_address(**value) is expected
 
 
 @pytest.mark.parametrize(
     "value,expected",
     (
         (
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
-            '0xd3cda913deb6f67967b99d67acdfa1712c293601',
-        ),
-        (
-            b'0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+            {'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
             '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
         ),
         (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-        ),
-        (
-            b'0XC6D9D2CD449A754C494264E1809C50E34D64562B',
+            {'primitive': b'0XC6D9D2CD449A754C494264E1809C50E34D64562B'},
             '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
         ),
         (
-            '0XC6D9D2CD449A754C494264E1809C50E34D64562B',
+            {'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562b'},
             '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
         ),
         (
-            'c6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-        ),
-        (
-            'C6D9D2CD449A754C494264E1809C50E34D64562B',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-        ),
-        (
-            '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9',
+            {'primitive': b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
             '0xc305c901078781c232a2a521c2af7980f8385ee9',
         ),
         (
-            b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9',
+            {'primitive': b'000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
             '0xc305c901078781c232a2a521c2af7980f8385ee9',
         ),
         (
-            '000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9',
+            {'hexstr': '305843364439443243443434394137353443343934323634453138303943353045333444363435363242'},
+            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+        ),
+        (
+            {'hexstr': '307863366439643263643434396137353463343934323634653138303963353065333464363435363262'},
+            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+        ),
+        (
+            {'hexstr': '307830303030303030303030303030303030303030303030303063333035633930313037383738316332333261326135323163326166373938306638333835656539'},
+            '0xc305c901078781c232a2a521c2af7980f8385ee9',
+        ),
+        (
+            {'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+        ),
+        (
+            {'text': '0XC6D9D2CD449A754C494264E1809C50E34D64562B'},
+            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+        ),
+        (
+            {'text': 'C6D9D2CD449A754C494264E1809C50E34D64562B'},
+            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+        ),
+        (
+            {'text': '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
+            '0xc305c901078781c232a2a521c2af7980f8385ee9',
+        ),
+        (
+            {'text': 'C6D9D2CD449A754C494264E1809C50E34D64562B'},
+            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+        ),
+        (
+            {'text': '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
             '0xc305c901078781c232a2a521c2af7980f8385ee9',
         ),
     )
 )
 def test_to_normalized_address(value, expected):
-    assert to_normalized_address(value) == expected
+    assert to_normalized_address(**value) == expected
 
 
 @pytest.mark.parametrize(
     "value,expected",
     (
         (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+            {'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
             '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
         ),
         (
-            'c6d9d2cd449a754c494264e1809c50e34d64562b',
+            {'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562b'},
+            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+        ),
+        (
+            {'hexstr': '307863366439643263643434396137353463343934323634653138303963353065333464363435363262'},
+            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+        ),
+        (
+            {'hexstr': '63366439643263643434396137353463343934323634653138303963353065333464363435363262'},
+            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+        ),
+        (
+            {'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+        ),
+        (
+            {'text': 'c6d9d2cd449a754c494264e1809c50e34d64562b'},
             '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
         ),
     )
 )
 def test_to_checksum_address(value, expected):
-    assert to_checksum_address(value) == expected
+    assert to_checksum_address(**value) == expected
 
 
 @pytest.mark.parametrize(
     "address1,address2,expected",
     (
-        (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
-            True,
-        ),
-        (
-            'c6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
-            True,
-        ),
-        (
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
-            '0xd3cda913deb6f67967b99d67acdfa1712c293601',
-            True,
-        ),
-        (
-            b'0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            True,
-        ),
-        (
-            b'0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc305c901078781c232a2a521c2af7980f8385ee9',
-            False,
-        ),
-        (
-            'c6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            True,
-        ),
-        (
-            'C6D9D2CD449A754C494264E1809C50E34D64562B',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            True,
-        ),
-        (
-            '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9',
-            '0xc305c901078781c232a2a521c2af7980f8385ee9',
-            True,
-        ),
-        (
-            b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            False,
-        ),
+	(
+	    {'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    {'primitive': b'0xc6d9d2cD449A754c494264e1809c50e34D64562b'},
+	    True,
+	),
+	(
+	    {'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    {'primitive': b'0xc6d9d2cD449A754c494264e1809c50e34D64562b'},
+	    True,
+	),
+	(
+	    {'hexstr': '307863366439643263643434396137353463343934323634653138303963353065333464363435363262'},
+	    {'text': '0xc6d9d2cD449A754c494264e1809c50e34D64562b'},
+	    True,
+	),
+	(
+	    {'text': 'c6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    {'text': '0xc6d9d2cD449A754c494264e1809c50e34D64562b'},
+	    True,
+	),
+	(
+	    {'primitive': b'c6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    {'text': '0xc6d9d2cD449A754c494264e1809c50e34D64562b'},
+	    True,
+	),
+	(
+	    {'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    {'text': '0xc305c901078781c232a2a521c2af7980f8385ee9'},
+	    False,
+	),
+	(
+	    {'text': 'C6D9D2CD449A754C494264E1809C50E34D64562B'},
+	    {'primitive': b'0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    True,
+	),
+	(
+	    {'primitive': b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
+	    {'text': '0xc305c901078781c232a2a521c2af7980f8385ee9'},
+	    True,
+	),
+	(
+	    {'primitive': b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
+	    {'hexstr': '307863333035633930313037383738316332333261326135323163326166373938306638333835656539'},
+	    True,
+	),
+	(
+	    {'primitive': b'0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9'},
+	    {'text': '0xc6d9d2cd449a754c494264e1809c50e34d64562b'},
+	    False,
+	),
     )
 )
 def test_is_same_address(address1, address2, expected):
@@ -233,33 +309,37 @@ def test_is_same_address(address1, address2, expected):
 @pytest.mark.parametrize(
     'value,expected',
     (
-        (
-            '0xd3cda913deb6f67967b99d67acdfa1712c293601',
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
-        ),
-        (
-            b'0xd3cda913deb6f67967b99d67acdfa1712c293601',
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
-        ),
-        (
-            '\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
-        ),
+	(
+	    {'text': '0xd3cda913deb6f67967b99d67acdfa1712c293601'},
+	    b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
+	),
+	(
+	    {'text': '0xD3CDA913DEB6F67967B99D67ACDFA1712C293601'},
+	    b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
+	),
+	(
+	    {'hexstr': '307864336364613931336465623666363739363762393964363761636466613137313263323933363031'},
+	    b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
+	),
+	(
+	    {'primitive': b'0xd3cda913deb6f67967b99d67acdfa1712c293601'},
+	    b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
+	),
     ),
 )
 def test_to_canonical_address(value, expected):
-    actual = to_canonical_address(value)
-    assert actual == expected
+    assert to_canonical_address(**value) == expected
 
 
 @pytest.mark.parametrize(
     'value,expected',
     (
-        (b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', True),
-        ('\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', False),
-        ('0xd3cda913deb6f67967b99d67acdfa1712c293601', False),
+	({'primitive': b'\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6A\x6B\x6C\x6D\x6E\x6F\x70\x71\x72\x73\x74'}, True),
+	({'hexstr': '5c7864335c7863645c7861395c7831335c7864655c7862365c78663679675c7862395c783964675c7861635c7864665c786131712c29365c7830317864'}, False),
+	({'text': '\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01'}, False),
+	({'text': '0xd3cda913deb6f67967b99d67acdfa1712c293601'}, False),
+	({'text': 'notAddress'}, False),
     )
 )
 def test_is_canonical_address(value, expected):
-    actual = is_canonical_address(value)
-    assert actual is expected
+    assert is_canonical_address(**value) == expected 

--- a/tests/formatting-utils/test_padding_left_and_right.py
+++ b/tests/formatting-utils/test_padding_left_and_right.py
@@ -1,6 +1,7 @@
 import pytest
 
 from eth_utils.formatting import (
+    is_prefixed,
     pad_left,
     pad_right,
 )
@@ -36,3 +37,17 @@ def test_pad_left(value, to_size, pad_with, expected):
 def test_pad_right(value, to_size, pad_with, expected):
     actual = pad_right(value, to_size, pad_with)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value,prefix,expected',
+    (
+        (b'test', b't', True),
+        (b'test', b'0', False),
+        ('test', 't', True),
+        ('test', '0', False),
+        ('test', b'0', False),
+    )
+)
+def test_is_prefixed(value, prefix, expected):
+    assert is_prefixed(value, prefix) is expected

--- a/tests/hexidecimal-utils/test_hex.py
+++ b/tests/hexidecimal-utils/test_hex.py
@@ -1,8 +1,42 @@
 import pytest
 
 from eth_utils import (
+    decode_hex,
+    encode_hex,
     is_hex,
 )
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('123456', b'\x124V'),
+        (b'123456', b'\x124V'),
+        ('0x123456', b'\x124V'),
+        (b'0x123456', b'\x124V'),
+    ),
+)
+def test_decode_hex(value, expected):
+    actual = decode_hex(value)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ({'primitive': b'foo'}, '0x666f6f'),
+        ({'primitive': b'\x01\x02\x03'}, '0x010203'),
+        ({'primitive': 0}, '0x00'),
+        ({'hexstr': '0x000F'}, '0x000f'),
+        ({'hexstr': '666f6f'}, '0x666f6f'),
+        ({'text': '\x01\x02\x03'}, '0x010203'),
+        ({'text': 'foo'}, '0x666f6f'),
+        ({'text': ''}, '0x'),
+    )
+)
+def test_encode_hex(value, expected):
+    actual = encode_hex(**value)
+    assert actual == expected
 
 
 @pytest.mark.parametrize(
@@ -34,7 +68,6 @@ from eth_utils import (
         (b'123456xx', False),  # non-hex character
         ('0x123456xx', False),  # non-hex character
         (b'0x123456xx', False),  # non-hex character
-        ('0\u0080', False),  # triggers different exceptions in py2 and py3
     ),
 )
 def test_is_hex(value, expected):


### PR DESCRIPTION
### What was wrong?
Functions that depended on deprecated `force_bytes` // `force_text` needed converting to the new conversion functions `to_text` // `to_bytes`

### How was it fixed?
- Deprecated `force_bytes` // `force_text`  and functions that depended on them .. `coerce_args_to_*` // `coerce_return_to_*`
- Converted functions that depended on these decorators to the new `.conversion` functions imported from web3.py

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/35525806-c8b65f1e-04e2-11e8-9ed8-2d58148f8e1c.png)
