### PR TITLE
Convert keccak from force_bytes

### DIFF
--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -12,7 +12,7 @@ def _abi_to_signature(abi):
 
 
 def function_signature_to_4byte_selector(event_signature):
-    return keccak(event_signature.replace(' ', ''))[:4]
+    return keccak(text=event_signature.replace(' ', ''))[:4]
 
 
 def function_abi_to_4byte_selector(function_abi):
@@ -21,7 +21,7 @@ def function_abi_to_4byte_selector(function_abi):
 
 
 def event_signature_to_log_topic(event_signature):
-    return keccak(event_signature.replace(' ', ''))
+    return keccak(text=event_signature.replace(' ', ''))
 
 
 def event_abi_to_log_topic(event_abi):

--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -112,7 +112,7 @@ def to_checksum_address(address):
     Makes a checksum address given a supported format.
     """
     norm_address = to_normalized_address(address)
-    address_hash = encode_hex(keccak(remove_0x_prefix(norm_address)))
+    address_hash = encode_hex(keccak(text=remove_0x_prefix(norm_address)))
 
     checksum_address = add_0x_prefix(''.join(
         (

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -3,14 +3,14 @@ try:
 except ImportError:
     from sha3 import sha3_256 as keccak_256
 
-from .string import (
-    force_bytes,
+from .conversions import (
+    to_bytes,
 )
 
 
-def keccak(value):
-    return keccak_256(force_bytes(value)).digest()
+def keccak(primitive=None, hexstr=None, text=None):
+    return keccak_256(to_bytes(primitive, hexstr, text)).digest()
 
 
 # ensure we have the *correct* hash function
-assert keccak('') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
+assert keccak(text='') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p"  # noqa: E501


### PR DESCRIPTION
### What was wrong?
`keccak256()` used to be deprecated `force_bytes`

### How was it fixed?
Converted function to use `to_bytes`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/35986558-9741ac82-0cb6-11e8-8678-3ff80031216f.png)
