### PR TITLE
Swap in eth-hash for pysha3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,58 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: lint
+  py35:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35
+  py36:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36
+  pypy3:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3
+workflows:
+  version: 2
+  test:
+    jobs:
+      - lint
+      - py35
+      - py36
+      - pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
       env: TOX_ENV=py35
     - python: "3.6"
       env: TOX_ENV=py36
-    - python: "pypy3"
-      env: TOX_ENV=pypy3
     - python: "3.5"
       env: TOX_ENV=lint
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 matrix:
   include:
-    - python: "3.4"
-      env: TOX_ENV=py34
     - python: "3.5"
       env: TOX_ENV=py35
     - python: "3.6"
       env: TOX_ENV=py36
+    - python: "pypy3"
+      env: TOX_ENV=pypy3
     - python: "3.5"
-      env: TOX_ENV=flake8
+      env: TOX_ENV=lint
 cache:
   pip: true
 install:

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -1,7 +1,4 @@
-try:
-    from sha3 import keccak_256
-except ImportError:
-    from sha3 import sha3_256 as keccak_256
+from eth_hash.auto import keccak as keccak_256
 
 from .conversions import (
     to_bytes,
@@ -9,7 +6,7 @@ from .conversions import (
 
 
 def keccak(primitive=None, hexstr=None, text=None):
-    return keccak_256(to_bytes(primitive, hexstr, text)).digest()
+    return keccak_256(to_bytes(primitive, hexstr, text))
 
 
 # ensure we have the *correct* hash function

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -7,7 +7,3 @@ from .conversions import (
 
 def keccak(primitive=None, hexstr=None, text=None):
     return keccak_256(to_bytes(primitive, hexstr, text))
-
-
-# ensure we have the *correct* hash function
-assert keccak(text='') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p"  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/ethereum/eth_utils',
     include_package_data=True,
     install_requires=[
-        "pysha3>=1.0.0,<2.0.0",
+        "eth-hash>=0.1.0a3,<0.2.0",
         "cytoolz>=0.8.2,<1.0.0",
     ],
     setup_requires=['setuptools-markdown'],

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{34,35,36}
-    flake8
+    py{35,36,py3}
+    lint
 
 [flake8]
 max-line-length= 100
@@ -14,11 +14,11 @@ commands=
 deps =
     -r{toxinidir}/requirements-dev.txt
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
+    pypy3: pypy3
 
-[testenv:flake8]
+[testenv:lint]
 basepython=python
 deps=flake8
 commands=flake8 {toxinidir}/eth_utils

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands=
     py.test {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
+    eth-hash[pycryptodome]
 basepython =
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?

Want to easily swap in keccak256 implementations.

### How was it fixed?

Use eth-hash library, with no backend specified in eth-utils

#### Cute Animal Picture

![Cute animal picture](https://i0.wp.com/greenarea.me/wp-content/uploads/2016/01/Angora-Rabbit4.jpg?fit=878%2C658)