### PR TITLE
Write validate conversion arguments decorator

### DIFF
--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -1,5 +1,5 @@
 from .decorators import (
-    assert_one_arg,
+    validate_conversion_arguments,
 )
 from .encoding import (
     big_endian_to_int,
@@ -19,7 +19,7 @@ from .types import (
 )
 
 
-@assert_one_arg
+@validate_conversion_arguments
 def to_hex(value=None, hexstr=None, text=None):
     """
     Auto converts any supported value into it's hex representation.
@@ -50,7 +50,7 @@ def to_hex(value=None, hexstr=None, text=None):
     )
 
 
-@assert_one_arg
+@validate_conversion_arguments
 def to_int(value=None, hexstr=None, text=None):
     """
     Converts value to it's integer representation.
@@ -75,7 +75,7 @@ def to_int(value=None, hexstr=None, text=None):
         return int(value)
 
 
-@assert_one_arg
+@validate_conversion_arguments
 def to_bytes(primitive=None, hexstr=None, text=None):
     if is_boolean(primitive):
         return b'\x01' if primitive else b'\x00'
@@ -92,7 +92,7 @@ def to_bytes(primitive=None, hexstr=None, text=None):
     raise TypeError("expected an int in first arg, or keyword of hexstr or text")
 
 
-@assert_one_arg
+@validate_conversion_arguments
 def to_text(primitive=None, hexstr=None, text=None):
     if hexstr is not None:
         return to_bytes(hexstr=hexstr).decode('utf-8')

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -5,6 +5,10 @@ from cytoolz import (
     identity,
 )
 
+from .types import (
+    is_text,
+)
+
 
 class combomethod(object):
     def __init__(self, method):
@@ -34,10 +38,30 @@ def _assert_one_val(*args, **kwargs):
         )
 
 
-def assert_one_arg(to_wrap):
+def _hexstr_or_text_kwarg_is_text_type(**kwargs):
+    value = kwargs['hexstr'] if 'hexstr' in kwargs else kwargs['text']
+    return is_text(value)
+
+
+def _assert_hexstr_or_text_kwarg_is_text_type(**kwargs):
+    if not _hexstr_or_text_kwarg_is_text_type(**kwargs):
+        raise TypeError(
+            "Arguments passed as hexstr or text must be of text type. "
+            "Instead, value was: %r" % (repr(next(list(kwargs.values()))))
+        )
+
+
+def validate_conversion_arguments(to_wrap):
+    """
+    Validates arguments for conversion functions.
+    - Only a single argument is present
+    - If it is 'hexstr' or 'text' that it is a text type
+    """
     @functools.wraps(to_wrap)
     def wrapper(*args, **kwargs):
         _assert_one_val(*args, **kwargs)
+        if len(args) is 0 and 'primitive' not in kwargs:
+            _assert_hexstr_or_text_kwarg_is_text_type(**kwargs)
         return to_wrap(*args, **kwargs)
     return wrapper
 

--- a/tests/decorator-utils/test_validate_conversion_arguments.py
+++ b/tests/decorator-utils/test_validate_conversion_arguments.py
@@ -1,0 +1,54 @@
+import pytest
+
+from eth_utils.decorators import (
+    validate_conversion_arguments,
+)
+
+
+@pytest.fixture()
+def mock_conversion_function():
+    @validate_conversion_arguments
+    def conversion_function(primitive=None, hexstr=None, text=None):
+        return True
+    
+    return conversion_function
+
+
+@pytest.mark.parametrize(
+    'val',
+    (
+        b'123',
+        123,
+        {},
+        lambda: None,
+    )
+)
+def test_decorator_rejects_non_text_types(mock_conversion_function, val):
+    with pytest.raises(TypeError):
+        mock_conversion_function(hexstr=val)
+
+
+@pytest.mark.parametrize(
+    'values',
+    (
+        {},
+        {'primitive': 'abc', 'hexstr': 'abc'},
+        {'primitive': 'abc', 'hexstr': 'abc', 'text': 'abc'},
+    )
+)
+def test_decorator_only_accepts_a_single_arg(mock_conversion_function, values):
+    with pytest.raises(TypeError):
+        mock_conversion_function(**values)
+
+
+@pytest.mark.parametrize(
+    'values',
+    (
+        {'primitive': 'abc'},
+        {'hexstr': 'abc'},
+        {'text': 'abc'},
+    )
+)
+def test_decorator_accepts_a_single_text_arg(mock_conversion_function, values):
+    actual = mock_conversion_function(**values)
+    assert actual is True


### PR DESCRIPTION
### What was wrong?
Non-text type arguments were getting processed by conversion functions

### How was it fixed?
Updated decorator from `assert_one_val` to `validate_conversion_arguments` which is the same except it also validates that arguments for `hexstr` or `text` are of text type.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/36235294-e4d25b9a-11ac-11e8-95fe-0820cb476407.png)

closes #60 