### PR TITLE
Update hex and int conversions to work with new decorator

### DIFF
--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -20,7 +20,7 @@ from .types import (
 
 
 @validate_conversion_arguments
-def to_hex(value=None, hexstr=None, text=None):
+def to_hex(primitive=None, hexstr=None, text=None):
     """
     Auto converts any supported value into it's hex representation.
 
@@ -33,31 +33,31 @@ def to_hex(value=None, hexstr=None, text=None):
     if text is not None:
         return encode_hex(text.encode('utf-8'))
 
-    if is_boolean(value):
-        return "0x1" if value else "0x0"
+    if is_boolean(primitive):
+        return "0x1" if primitive else "0x0"
 
-    if isinstance(value, bytes):
-        return encode_hex(value)
-    elif is_string(value):
-        return to_hex(text=value)
+    if isinstance(primitive, bytes):
+        return encode_hex(primitive)
+    elif is_string(primitive):
+        return to_hex(text=primitive)
 
-    if is_integer(value):
-        return hex(value)
+    if is_integer(primitive):
+        return hex(primitive)
 
     raise TypeError(
         "Unsupported type: '{0}'.  Must be one of: bool, str, bytes"
-        "or int.".format(repr(type(value)))
+        "or int.".format(repr(type(primitive)))
     )
 
 
 @validate_conversion_arguments
-def to_int(value=None, hexstr=None, text=None):
+def to_int(primitive=None, hexstr=None, text=None):
     """
     Converts value to it's integer representation.
 
     Values are converted this way:
 
-     * value:
+     * primitive:
        * bytes: big-endian integer
        * bool: True => 1, False => 0
      * hexstr: interpret hex as integer
@@ -67,12 +67,12 @@ def to_int(value=None, hexstr=None, text=None):
         return int(hexstr, 16)
     elif text is not None:
         return int(text)
-    elif isinstance(value, bytes):
-        return big_endian_to_int(value)
-    elif isinstance(value, str):
+    elif isinstance(primitive, bytes):
+        return big_endian_to_int(primitive)
+    elif isinstance(primitive, str):
         raise TypeError("Pass in strings with keyword hexstr or text")
     else:
-        return int(value)
+        return int(primitive)
 
 
 @validate_conversion_arguments

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -51,15 +51,27 @@ def _assert_hexstr_or_text_kwarg_is_text_type(**kwargs):
         )
 
 
+def _validate_supported_kwarg(kwargs):
+    if next(iter(kwargs)) not in ['primitive', 'hexstr', 'text']:
+        raise TypeError(
+            "Kwarg must be 'primitive', 'hexstr', or 'text'. "
+            "Instead, kwarg was: %r" % (next(iter(kwargs)))
+        )
+
+
 def validate_conversion_arguments(to_wrap):
     """
     Validates arguments for conversion functions.
     - Only a single argument is present
+    - Kwarg must be 'primitive' 'hexstr' or 'text'
     - If it is 'hexstr' or 'text' that it is a text type
     """
     @functools.wraps(to_wrap)
     def wrapper(*args, **kwargs):
         _assert_one_val(*args, **kwargs)
+        if kwargs:
+            _validate_supported_kwarg(kwargs)
+
         if len(args) is 0 and 'primitive' not in kwargs:
             _assert_hexstr_or_text_kwarg_is_text_type(**kwargs)
         return to_wrap(*args, **kwargs)

--- a/tests/decorator-utils/test_validate_conversion_arguments.py
+++ b/tests/decorator-utils/test_validate_conversion_arguments.py
@@ -10,7 +10,6 @@ def mock_conversion_function():
     @validate_conversion_arguments
     def conversion_function(primitive=None, hexstr=None, text=None):
         return True
-    
     return conversion_function
 
 
@@ -23,9 +22,23 @@ def mock_conversion_function():
         lambda: None,
     )
 )
-def test_decorator_rejects_non_text_types(mock_conversion_function, val):
+def test_decorator_rejects_non_text_type_args_for_hexstr_kwarg(mock_conversion_function, val):
     with pytest.raises(TypeError):
         mock_conversion_function(hexstr=val)
+
+
+@pytest.mark.parametrize(
+    'val',
+    (
+        b'123',
+        123,
+        {},
+        lambda: None,
+    )
+)
+def test_decorator_rejects_non_text_type_args_for_text_kwarg(mock_conversion_function, val):
+    with pytest.raises(TypeError):
+        mock_conversion_function(text=val)
 
 
 @pytest.mark.parametrize(
@@ -39,6 +52,11 @@ def test_decorator_rejects_non_text_types(mock_conversion_function, val):
 def test_decorator_only_accepts_a_single_arg(mock_conversion_function, values):
     with pytest.raises(TypeError):
         mock_conversion_function(**values)
+
+
+def test_decorator_rejects_invalid_kwarg(mock_conversion_function):
+    with pytest.raises(TypeError):
+        mock_conversion_function(value='123')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
`to_hex` and `to_int` conversion function kwargs were not updated to be compatible with new decorator `validate_conversion_arguments`

### How was it fixed?
Update kwargs

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/36313714-ac1f0e30-12ef-11e8-9927-4a9d8f9da06d.png)

thanks for catching this @carver 
