### PR TITLE
Strictly accept text types for decode_hex

### DIFF
--- a/eth_utils/hexidecimal.py
+++ b/eth_utils/hexidecimal.py
@@ -17,8 +17,8 @@ from .string import (
 
 @coerce_return_to_bytes
 def decode_hex(value):
-    if not is_string(value):
-        raise TypeError('Value must be an instance of str or unicode')
+    if not is_text(value):
+        raise TypeError('Value must be an instance of str')
     return codecs.decode(remove_0x_prefix(value), 'hex')
 
 


### PR DESCRIPTION
### What was wrong?
decode_hex() was passed a bytes value, and it wasn't caught until deep in the eth-utils stack. 

### How was it fixed?
Immediately reject non-str values to decode_hex

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/36491145-53d6935a-16e7-11e8-845a-70e9f014aaa2.png)

resolves #68 
