### PR TITLE
Apply formatters to sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,25 @@ IndexError: Too many formatters for sequence: 3 formatters for (1.2, 3.4)
 
 #### `combine_argument_formatters(*formatters)` -> lambda <list_like>: <new_list_like>
 
-*This is a bit like a curried version of `apply_formatters_to_sequence`, but
-you supply the functions as `*args`, and so you **must** create the combined
-formatter function and then apply it.*
+**DEPRECATED**
+
+You can replace all current versions of:
+
+```py
+>>> from eth_utils import combine_argument_formatters
+
+>>> list_formatter = combine_argument_formatters(bool, int, str)
+```
+
+With the newer, preferred:
+
+```py
+>>> from eth_utils.curried import apply_formatters_to_sequence
+
+>>> list_formatter = apply_formatters_to_sequence((bool, int, str))
+```
+
+The old usage works like:
 
 Combine several formatters to be applied to a list-like value, each formatter
 at the position it was supplied. The new formatter will return the same type as

--- a/README.md
+++ b/README.md
@@ -239,9 +239,13 @@ For example:
 >>> list_formatter((1.2, 3.4, 5.6))
 (True, 3, '5.6')
 
-# it will pass through items longer than the number of formatters supplied
+# Formatters and list-like value must be the same length
+
 >>> list_formatter((1.2, 3.4, 5.6, 7.8))
-[True, 3, '5.6', 7.8]
+IndexError: Too few formatters for sequence: 3 formatters for (1.2, 3.4, 5.6, 7.8)
+
+>>> list_formatter((1.2, 3.4))
+IndexError: Too many formatters for sequence: 3 formatters for (1.2, 3.4)
 ```
 
 
@@ -797,7 +801,7 @@ At the shell:
 $ python -m eth_utils
 
 Python version:
-3.5.3 (default, Nov 23 2017, 11:34:05) 
+3.5.3 (default, Nov 23 2017, 11:34:05)
 [GCC 6.3.0 20170406]
 
 Operating System: Linux-4.10.0-42-generic-x86_64-with-Ubuntu-17.04-zesty

--- a/README.md
+++ b/README.md
@@ -222,7 +222,34 @@ It returns the same type as the `list_like` argument
 ```
 
 
+#### `apply_formatters_to_sequence(formatters, <list_like>)` -> <new_list_like>
+
+This function will apply each formatter at to the list-like value, at the
+position it was supplied. It returns the same time as the `list_like` argument.
+For example:
+
+```py
+>>> from eth_utils.curried import apply_formatters_to_sequence
+
+>>> list_formatter = apply_formatters_to_sequence([bool, int, str])
+
+>>> list_formatter([1.2, 3.4, 5.6])
+[True, 3, '5.6']
+
+>>> list_formatter((1.2, 3.4, 5.6))
+(True, 3, '5.6')
+
+# it will pass through items longer than the number of formatters supplied
+>>> list_formatter((1.2, 3.4, 5.6, 7.8))
+[True, 3, '5.6', 7.8]
+```
+
+
 #### `combine_argument_formatters(*formatters)` -> lambda <list_like>: <new_list_like>
+
+*This is a bit like a curried version of `apply_formatters_to_sequence`, but
+you supply the functions as `*args`, and so you **must** create the combined
+formatter function and then apply it.*
 
 Combine several formatters to be applied to a list-like value, each formatter
 at the position it was supplied. The new formatter will return the same type as

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -26,6 +26,7 @@ from .applicators import (  # noqa: F401
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
+    apply_formatters_to_sequence,
     apply_key_map,
     apply_one_of_formatters,
     combine_argument_formatters,

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -34,6 +34,10 @@ def combine_argument_formatters(*formatters):
     ))
 
 
+def apply_formatters_to_sequence(formatters, sequence):
+    return combine_argument_formatters(*formatters)(sequence)
+
+
 def apply_formatter_if(condition, formatter, value):
     if condition(value):
         return formatter(value)

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,3 +1,5 @@
+import warnings
+
 from cytoolz.functoolz import (
     compose,
     curry,
@@ -26,6 +28,14 @@ def apply_formatter_at_index(formatter, at_index, value):
 
 
 def combine_argument_formatters(*formatters):
+    warnings.warn(DeprecationWarning(
+        "combine_argument_formatters(formatter1, formatter2)([item1, item2])"
+        "has been deprecated and will be removed in a subsequent major version "
+        "release of the eth-utils library. Update your calls to use "
+        "apply_formatters_to_sequence([formatter1, formatter2], [item1, item2]) "
+        "instead."
+    ))
+
     _formatter_at_index = curry(apply_formatter_at_index)
     return compose(*(
         _formatter_at_index(formatter, index)

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -34,8 +34,21 @@ def combine_argument_formatters(*formatters):
     ))
 
 
+@return_arg_type(1)
 def apply_formatters_to_sequence(formatters, sequence):
-    return combine_argument_formatters(*formatters)(sequence)
+    if len(formatters) > len(sequence):
+        raise IndexError("Too many formatters for sequence: {} formatters for {!r}".format(
+            len(formatters),
+            sequence,
+        ))
+    elif len(formatters) < len(sequence):
+        raise IndexError("Too few formatters for sequence: {} formatters for {!r}".format(
+            len(formatters),
+            sequence,
+        ))
+    else:
+        for formatter, item in zip(formatters, sequence):
+            yield formatter(item)
 
 
 def apply_formatter_if(condition, formatter, value):

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -10,6 +10,7 @@ from eth_utils import (
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
+    apply_formatters_to_sequence,
     apply_key_map,
     apply_one_of_formatters,
     apply_to_return_value,
@@ -70,6 +71,7 @@ apply_formatter_at_index = curry(apply_formatter_at_index)
 apply_formatter_if = curry(apply_formatter_if)
 apply_formatter_to_array = curry(apply_formatter_to_array)
 apply_formatters_to_dict = curry(apply_formatters_to_dict)
+apply_formatters_to_sequence = curry(apply_formatters_to_sequence)
 apply_key_map = curry(apply_key_map)
 apply_one_of_formatters = curry(apply_one_of_formatters)
 flatten_return = curry(flatten_return)

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -1,10 +1,6 @@
 import functools
 import itertools
 
-from cytoolz import (
-    identity,
-)
-
 from .types import (
     is_text,
 )
@@ -85,11 +81,8 @@ def return_arg_type(at_position):
     def decorator(to_wrap):
         @functools.wraps(to_wrap)
         def wrapper(*args, **kwargs):
-            try:
-                ReturnType = type(args[at_position])
-            except IndexError:
-                ReturnType = identity
             result = to_wrap(*args, **kwargs)
+            ReturnType = type(args[at_position])
             return ReturnType(result)
         return wrapper
     return decorator

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -7,6 +7,7 @@ from eth_utils.curried import (
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
+    apply_formatters_to_sequence,
     apply_key_map,
     apply_one_of_formatters,
     is_list_like,
@@ -132,31 +133,30 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
         assert targetted_formatter(value) == expected
 
 
-@pytest.mark.parametrize(
-    'formatters, value, expected',
+SEQUENCE_FORMATTER_PARAMETERS = (
     (
-        (
-            [bool, int, str],
-            (1.2, 3.4, 5.6),
-            (True, 3, '5.6'),
-        ),
-        (
-            [bool, int],
-            (1.2, 3.4, 5.6),
-            (True, 3, 5.6),
-        ),
-        (
-            [bool, int],
-            [1.2, 3.4, 5.6],
-            [True, 3, 5.6],
-        ),
-        (
-            [bool, int, str, float],
-            (1.2, 3.4, 5.6),
-            IndexError,
-        ),
+        [bool, int, str],
+        (1.2, 3.4, 5.6),
+        (True, 3, '5.6'),
+    ),
+    (
+        [bool, int],
+        (1.2, 3.4, 5.6),
+        (True, 3, 5.6),
+    ),
+    (
+        [bool, int],
+        [1.2, 3.4, 5.6],
+        [True, 3, 5.6],
+    ),
+    (
+        [bool, int, str, float],
+        (1.2, 3.4, 5.6),
+        IndexError,
     ),
 )
+
+@pytest.mark.parametrize('formatters, value, expected', SEQUENCE_FORMATTER_PARAMETERS)
 def test_combine_argument_formatters(formatters, value, expected):
     list_formatter = eth_utils.combine_argument_formatters(*formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
@@ -164,6 +164,25 @@ def test_combine_argument_formatters(formatters, value, expected):
             list_formatter(value)
     else:
         assert list_formatter(value) == expected
+
+
+@pytest.mark.parametrize('formatters, value, expected', SEQUENCE_FORMATTER_PARAMETERS)
+def test_apply_formatters_to_sequence_curried(formatters, value, expected):
+    list_formatter = apply_formatters_to_sequence(formatters)
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            list_formatter(value)
+    else:
+        assert list_formatter(value) == expected
+
+
+@pytest.mark.parametrize('formatters, value, expected', SEQUENCE_FORMATTER_PARAMETERS)
+def test_apply_formatters_to_sequence(formatters, value, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            eth_utils.apply_formatters_to_sequence(formatters, value)
+    else:
+        assert eth_utils.apply_formatters_to_sequence(formatters, value) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -140,14 +140,9 @@ SEQUENCE_FORMATTER_PARAMETERS = (
         (True, 3, '5.6'),
     ),
     (
-        [bool, int],
-        (1.2, 3.4, 5.6),
-        (True, 3, 5.6),
-    ),
-    (
-        [bool, int],
+        [bool, int, str],
         [1.2, 3.4, 5.6],
-        [True, 3, 5.6],
+        [True, 3, '5.6'],
     ),
     (
         [bool, int, str, float],
@@ -156,7 +151,15 @@ SEQUENCE_FORMATTER_PARAMETERS = (
     ),
 )
 
-@pytest.mark.parametrize('formatters, value, expected', SEQUENCE_FORMATTER_PARAMETERS)
+LOOSE_SEQUENCE_FORMATTER_PARAMETERS = SEQUENCE_FORMATTER_PARAMETERS + (
+    (
+        [bool, int],
+        (1.2, 3.4, 5.6),
+        (True, 3, 5.6),
+    ),
+)
+
+@pytest.mark.parametrize('formatters, value, expected', LOOSE_SEQUENCE_FORMATTER_PARAMETERS)
 def test_combine_argument_formatters(formatters, value, expected):
     list_formatter = eth_utils.combine_argument_formatters(*formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
@@ -165,8 +168,15 @@ def test_combine_argument_formatters(formatters, value, expected):
     else:
         assert list_formatter(value) == expected
 
+STRICT_SEQUENCE_FORMATTER_PARAMETERS = SEQUENCE_FORMATTER_PARAMETERS + (
+    (
+        [bool, int],
+        (1.2, 3.4, 5.6),
+        IndexError,
+    ),
+)
 
-@pytest.mark.parametrize('formatters, value, expected', SEQUENCE_FORMATTER_PARAMETERS)
+@pytest.mark.parametrize('formatters, value, expected', STRICT_SEQUENCE_FORMATTER_PARAMETERS)
 def test_apply_formatters_to_sequence_curried(formatters, value, expected):
     list_formatter = apply_formatters_to_sequence(formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
@@ -176,7 +186,7 @@ def test_apply_formatters_to_sequence_curried(formatters, value, expected):
         assert list_formatter(value) == expected
 
 
-@pytest.mark.parametrize('formatters, value, expected', SEQUENCE_FORMATTER_PARAMETERS)
+@pytest.mark.parametrize('formatters, value, expected', STRICT_SEQUENCE_FORMATTER_PARAMETERS)
 def test_apply_formatters_to_sequence(formatters, value, expected):
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):


### PR DESCRIPTION
### What was wrong?

`combine_argument_formatters` sticks out as inconsistent with the other `apply_*` methods.

- In the existing API, it was not easily (feasibly?) curryable, so it could not be applied immediately.
- Because it couldn't be applied, naming it `apply_<something>` didn't make sense.
- But now it sticks out as inconsistent, and more difficult to remember the pattern

### How was it fixed?

I'm just floating this concept. I think I like it, but I'm not 100% sure:

- Switch the API so that the formatters are supplied in an iterable in argument one, and then argument two has the iterable to apply the formatters to.
- The method is now curry-able
- The name can be more consistent, and still be semantically accurate

`apply_formatters_to_sequence` now applies each formatter to each position in the given sequence.

_Should we get rid of `combine_argument_formatters` altogether?_ It doesn't provide much/any marginal value over the curried version of `apply_formatters_to_sequence`.

It is used in a couple places already, but better now than having to wait for v2, if we think removing the method makes sense.

#### Cute Animal Picture

![Cute animal picture](https://i0.wp.com/rooftopantics.com/wp-content/uploads/2016/10/australia_wildlife_NT_cute.jpg?resize=640%2C480)
