### PR TITLE
Update apply key map to catch conflicting keys

### DIFF
--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -96,6 +96,21 @@ def apply_one_of_formatters(formatter_condition_pairs, value):
 
 @to_dict
 def apply_key_map(key_mappings, value):
+    key_conflicts = set(
+        value.keys()
+    ).difference(
+        key_mappings.keys()
+    ).intersection(
+        v
+        for k, v
+        in key_mappings.items()
+        if v in value
+    )
+    if key_conflicts:
+        raise KeyError(
+            "Could not apply key map due to conflicting key(s): {}".format(key_conflicts)
+        )
+
     for key, item in value.items():
         if key in key_mappings:
             yield key_mappings[key], item

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -1,3 +1,4 @@
+import collections
 import pytest
 
 import eth_utils
@@ -71,6 +72,32 @@ def test_apply_key_map(formatter, value, expected):
 
     mapper = apply_key_map(formatter)
     assert mapper(value) == expected
+
+
+@pytest.mark.parametrize(
+    'formatter, value',
+    (
+        (
+            {'a': 'b'},
+            {'b': 3},
+        ),
+        (
+            {'a': 'b'},
+            {'a': 2, 'b': 3},
+        ),
+        (
+            {'a': 'b'},
+            collections.OrderedDict((('a', 2), ('b', 3))),
+        ),
+        (
+            {'a': 'b'},
+            collections.OrderedDict((('b', 3), ('a', 2))),
+        ),
+    ),
+)
+def test_apply_key_map_with_key_conflicts_raises_exception(formatter, value):
+    with pytest.raises(KeyError):
+        eth_utils.apply_key_map(formatter, value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
`apply_key_map` behaved unpredictably with conflicting keys

### How was it fixed?
Write a catch to recognize conflicting keys and raise a `KeyError`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/38209740-89625a7c-3672-11e8-96b2-a5bf91333da9.png)

