### PR TITLE
Add type hints to decorator

### DIFF
--- a/eth_utils/functional.py
+++ b/eth_utils/functional.py
@@ -1,22 +1,48 @@
 import collections
 import functools
 import itertools
+from typing import (  # noqa: F401
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from .toolz import compose as _compose
 
 
-def identity(value):
+T = TypeVar("T")
+
+
+def identity(value: T) -> T:
     return value
 
 
-def combine(f, g):
+TGIn = TypeVar("TGIn")
+TGOut = TypeVar("TGOut")
+TFOut = TypeVar("TFOut")
+
+
+def combine(
+    f: Callable[[TGOut], TFOut], g: Callable[[TGIn], TGOut]
+) -> Callable[[TGIn], TFOut]:
     return lambda x: f(g(x))
 
 
-def apply_to_return_value(callback):
+def apply_to_return_value(
+    callback: Callable[..., T]
+) -> Callable[..., Callable[..., T]]:
     def outer(fn):
+        # We would need to type annotate *args and **kwargs but doing so segfaults
+        # the PyPy builds. We ignore instead.
         @functools.wraps(fn)
-        def inner(*args, **kwargs):
+        def inner(*args, **kwargs) -> T:  # type: ignore
             return callback(fn(*args, **kwargs))
 
         return inner
@@ -24,11 +50,23 @@ def apply_to_return_value(callback):
     return outer
 
 
-to_tuple = apply_to_return_value(tuple)
-to_list = apply_to_return_value(list)
-to_dict = apply_to_return_value(dict)
-to_ordered_dict = apply_to_return_value(collections.OrderedDict)
-to_set = apply_to_return_value(set)
+TVal = TypeVar("TVal")
+TKey = TypeVar("TKey")
+to_tuple = apply_to_return_value(
+    tuple
+)  # type: Callable[[Callable[..., Iterable[TVal]]], Callable[..., Tuple[TVal, ...]]]  # noqa: E501
+to_list = apply_to_return_value(
+    list
+)  # type: Callable[[Callable[..., Iterable[TVal]]], Callable[..., List[TVal]]]  # noqa: E501
+to_set = apply_to_return_value(
+    set
+)  # type: Callable[[Callable[..., Iterable[TVal]]], Callable[..., Set[TVal]]]  # noqa: E501
+to_dict = apply_to_return_value(
+    dict
+)  # type: Callable[[Callable[..., Iterable[Union[Mapping[TVal, TKey], Tuple[TVal, TKey]]]]], Callable[..., Dict[TKey, TVal]]]  # noqa: E501
+to_ordered_dict = apply_to_return_value(
+    collections.OrderedDict
+)  # type: Callable[[Callable[..., Iterable[Union[Mapping[TVal, TKey], Tuple[TVal, TKey]]]]], Callable[..., collections.OrderedDict[TKey, TVal]]]  # noqa: E501
 sort_return = _compose(to_tuple, apply_to_return_value(sorted))
 flatten_return = _compose(
     to_tuple, apply_to_return_value(itertools.chain.from_iterable)

--- a/fixtures/mypy/apply_to_return_value_decorator.py
+++ b/fixtures/mypy/apply_to_return_value_decorator.py
@@ -1,0 +1,17 @@
+from typing import (
+    List,
+    Tuple,
+)
+from eth_utils import (
+    apply_to_return_value
+)
+
+def wrap_as_list(value: int) -> List[int]:
+    return [value]
+
+@apply_to_return_value(wrap_as_list)
+def return_value() -> int:
+    return 1
+
+x = return_value()
+reveal_type(x)

--- a/fixtures/mypy/to_dict_decorator.py
+++ b/fixtures/mypy/to_dict_decorator.py
@@ -1,0 +1,14 @@
+from typing import (
+    List,
+    Tuple
+)
+from eth_utils import (
+    to_dict
+)
+
+@to_dict
+def return_value() -> List[Tuple[int, int]]:
+    return [(1, 2)]
+
+x = return_value()
+reveal_type(x)

--- a/fixtures/mypy/to_list_decorator.py
+++ b/fixtures/mypy/to_list_decorator.py
@@ -1,0 +1,13 @@
+from typing import (
+    Tuple
+)
+from eth_utils import (
+    to_list
+)
+
+@to_list
+def return_value() -> Tuple[int, int]:
+    return (1, 2)
+
+x = return_value()
+reveal_type(x)

--- a/fixtures/mypy/to_ordered_dict_decorator.py
+++ b/fixtures/mypy/to_ordered_dict_decorator.py
@@ -1,0 +1,14 @@
+from typing import (
+    List,
+    Tuple
+)
+from eth_utils import (
+    to_ordered_dict
+)
+
+@to_ordered_dict
+def return_value() -> List[Tuple[int, int]]:
+    return [(1, 2)]
+
+x = return_value()
+reveal_type(x)

--- a/fixtures/mypy/to_set_decorator.py
+++ b/fixtures/mypy/to_set_decorator.py
@@ -1,0 +1,14 @@
+from typing import (
+    List,
+    Tuple
+)
+from eth_utils import (
+    to_set
+)
+
+@to_set
+def return_value() -> List[int]:
+    return [1, 1, 2]
+
+x = return_value()
+reveal_type(x)

--- a/fixtures/mypy/to_tuple_decorator.py
+++ b/fixtures/mypy/to_tuple_decorator.py
@@ -1,0 +1,13 @@
+from typing import (
+    List
+)
+from eth_utils import (
+    to_tuple
+)
+
+@to_tuple
+def return_value() -> List[int]:
+    return [1, 2]
+
+x = return_value()
+reveal_type(x)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ extras_require = {
     'lint': [
         'black>=18.6b4,<19',
         'flake8>=3.5.0,<4.0.0',
-        "mypy<0.600",
+        'mypy<0.600',
+        'pytest>=3.4.1,<4.0.0',
     ],
     'test': [
         'hypothesis>=3.4.2,<4.0.0',

--- a/tests/functional-utils/type_inference_tests.py
+++ b/tests/functional-utils/type_inference_tests.py
@@ -1,0 +1,71 @@
+import mypy.api
+from typing import List
+
+import pytest
+
+MYPY_ARGS = ["--ignore-missing-imports"]
+FIXTURE_DIR = "fixtures/mypy/"
+
+
+def fixture_dir(val: str):
+    return FIXTURE_DIR + val
+
+
+def check_mypy_run(
+    cmd_line: List[str],
+    expected_out: str,
+    expected_err: str = "",
+    expected_returncode: int = 1,
+) -> None:
+    """Helper to run mypy and check the output."""
+    out, err, returncode = mypy.api.run(cmd_line)
+    assert out == expected_out, err
+    assert err == expected_err, out
+    assert returncode == expected_returncode, returncode
+
+
+# The following tests all run code snippets through mypy that contain a
+# `reveal_type` statement, and then match the mypy output against our expectations
+@pytest.mark.parametrize(
+    "fixture,message",
+    (
+        (
+            fixture_dir("to_tuple_decorator.py"),
+            fixture_dir(
+                "to_tuple_decorator.py:13: error: Revealed type is 'builtins.tuple[builtins.int*]'\n"
+            ),
+        ),
+        (
+            fixture_dir("to_list_decorator.py"),
+            fixture_dir(
+                "to_list_decorator.py:13: error: Revealed type is 'builtins.list[builtins.int*]'\n"
+            ),
+        ),
+        (
+            fixture_dir("to_set_decorator.py"),
+            fixture_dir(
+                "to_set_decorator.py:14: error: Revealed type is 'builtins.set[builtins.int*]'\n"
+            ),
+        ),
+        (
+            fixture_dir("to_dict_decorator.py"),
+            fixture_dir(
+                "to_dict_decorator.py:14: error: Revealed type is 'builtins.dict[builtins.int*, builtins.int*]'\n"
+            ),
+        ),
+        (
+            fixture_dir("to_ordered_dict_decorator.py"),
+            fixture_dir(
+                "to_ordered_dict_decorator.py:14: error: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.int*]'\n"
+            ),
+        ),
+        (
+            fixture_dir("apply_to_return_value_decorator.py"),
+            fixture_dir(
+                "apply_to_return_value_decorator.py:17: error: Revealed type is 'builtins.list*[builtins.int]'\n"
+            ),
+        ),
+    ),
+)
+def test_type_inference(fixture, message):
+    check_mypy_run(MYPY_ARGS + [fixture], message)

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ basepython=
     mypy: mypy
     pypy3: pypy3
 
+
 [testenv:lint]
 whitelist_externals=black
 basepython=python3.6
@@ -33,3 +34,4 @@ commands=
     flake8 {toxinidir}/eth_utils
     mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p eth_utils
     black --check --diff {toxinidir}/eth_utils/ --check --diff {toxinidir}/tests/
+    py.test {posargs:tests}/functional-utils/type_inference_tests.py


### PR DESCRIPTION
### What was wrong?

This is a follow up of the discussion @jannikluhn and I had [here](https://github.com/ethereum/py-evm/pull/555#discussion_r181344706)

Currently, every usage of  `apply_to_return_value` and all the related decorators such as `to_list`, `to_dict` etc basically erase valuable type information.

Consider this:

```python
@to_list
def return_tuple():
    return (1, 2)

x = return_tuple()
x = 'foo'
```

Currently `mypy` does not catch this because it has no idea what `x` is and only recognizes it as `Any` leaving us vulnerable to such bugs.

### How was it fixed?

Added type hints to `apply_to_return_value`. Now `mypy` is able to properly infer the type and catch these bugs.

Considering how much we rely on these decorators this change has a relatively high impact so I'm opening this PR early to evaluate if you'd be generally supportive of such a change? 

This PR is still pretty much WIP, needs more testing and I'd also like to figure out the best way to add automated tests for this.

#### Cute Animal Picture

![Cute animal picture]()
