### PR TITLE
Faster int_to_big_endian implementation

### DIFF
--- a/eth_utils/encoding.py
+++ b/eth_utils/encoding.py
@@ -1,10 +1,6 @@
-import math
-
-
 def int_to_big_endian(value):
-    byte_length = max(math.ceil(value.bit_length() / 8), 1)
-    return value.to_bytes(byte_length, byteorder='big')
+    return value.to_bytes((value.bit_length() + 7) // 8 or 1, 'big')
 
 
 def big_endian_to_int(value):
-    return int.from_bytes(value, byteorder='big')
+    return int.from_bytes(value, 'big')


### PR DESCRIPTION
### What was wrong?

Opportunity for speed improvements for `int_to_big_endian`

### How was it fixed?

This implementation is 20% faster than the original.  The inlining of the `byte_length` gains an extra ~1-2% speed for what feels like a minor hit to readability.

```python
import time
import math


def profile(to_wrap, runs=100000):
    start = time.time()
    for i in range(1, runs + 1): to_wrap(i)
    duration = time.time() - start
    print(f'took {duration} s to run {runs} times. {duration*1000000/runs} us per run')


def int_to_big_endian(value):
    byte_length = max(math.ceil(value.bit_length() / 8), 1)
    return value.to_bytes(byte_length, byteorder='big')


def or_int_to_big_endian(value):
    byte_length = math.ceil(value.bit_length() / 8) or 1
    return value.to_bytes(byte_length, byteorder='big')

def new_int_to_big_endian(value):
    return value.to_bytes(math.ceil(value.bit_length() / 8) or 1, byteorder='big')

print('origin')
profile(int_to_big_endian)

print('or')
profile(or_int_to_big_endian)

print('new')
profile(new_int_to_big_endian)
```

```
origin
took 0.09991788864135742 s to run 100000 times. 0.9991788864135742 us per run
or
took 0.08073997497558594 s to run 100000 times. 0.8073997497558594 us per run
new
took 0.0774850845336914 s to run 100000 times. 0.7748508453369141 us per run
```

#### Cute Animal Picture

![10f5103e8cc6a8f81870b648f207dfec](https://user-images.githubusercontent.com/824194/38901910-5fd7fb54-425b-11e8-8ea4-874899c9de5c.jpg)

