### PR TITLE
Deprecate the keccak function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ common: &common
           fi
     - restore_cache:
         keys:
-          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - v0-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -37,7 +37,7 @@ common: &common
           - ~/.cache/pip
           - ~/.local
           - ./eggs
-        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        key: v0-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
   lint:

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -1,3 +1,5 @@
+import warnings
+
 from eth_hash.auto import keccak as keccak_256
 
 from .conversions import (
@@ -6,4 +8,7 @@ from .conversions import (
 
 
 def keccak(primitive=None, hexstr=None, text=None):
+    warnings.warn(DeprecationWarning(
+        "The `eth_utils.keccak()` function has been deprecated and will be removed in a "
+        "future version. You should update your code to use eth_hash.auto.keccak instead."))
     return keccak_256(to_bytes(primitive, hexstr, text))


### PR DESCRIPTION
It just added support for text/hex to eth_hash's version, but that has a
significant performance impact and was not really used anywhere, so
deprecating it now so that it can be removed in a future version.

Closes: #95