### PR TITLE
Expand currency test suite to fuzz test using float values

### DIFF
--- a/tests/currency-utils/test_currency_tools.py
+++ b/tests/currency-utils/test_currency_tools.py
@@ -100,6 +100,11 @@ def test_from_wei(value, expected):
 def test_to_wei(value, expected):
     assert to_wei(*value) == decimal.Decimal(expected)
 
+@given(
+    value=st.floats(min_value=0, max_value=1),
+)
+def test_to_wei_float(value):
+    assert from_wei(to_wei(value, 'ether'), 'ether') == decimal.Decimal(str(value))
 
 @pytest.mark.parametrize(
     'value,unit',


### PR DESCRIPTION
I have add test_to_wei_float in test_currency_tools, but the test fail

```
AssertionError: assert Decimal('2.22E-15') == Decimal('2.2204460492503135E-15')
where Decimal('2.22E-15') = from_wei(2220, 'ether')
where 2220 = to_wei(2.2204460492503135e-15, 'ether')
and   Decimal('2.2204460492503135E-15') = <class 'decimal.Decimal'>('2.2204460492503135e-15')
where <class 'decimal.Decimal'> = decimal.Decimal
and   '2.2204460492503135e-15' = str(2.2204460492503135e-15)
```
In `to_wei`, should we check decimal precision of floats to throw an error instead of silently roundup the return value `int(result_value)`?

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/39254739/40214323-3ef6e12a-5a84-11e8-9a32-0a84bf9b577f.jpg)
