### PR TITLE
Add replace_exceptions decorator to decorators.py

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -86,3 +86,23 @@ def return_arg_type(at_position):
             return ReturnType(result)
         return wrapper
     return decorator
+
+
+def replace_exceptions(old_to_new_exceptions):
+    '''
+    Replaces old exceptions with new exceptions, to be raised instead.
+    '''
+    old_exceptions = tuple(old_to_new_exceptions.keys())
+
+    def decorator(to_wrap):
+        @functools.wraps(to_wrap)
+        def wrapper(*args, **kwargs):
+            try:
+                return to_wrap(*args, **kwargs)
+            except old_exceptions as e:
+                try:
+                    raise old_to_new_exceptions[type(e)] from e
+                except KeyError:
+                    raise TypeError("could not look up new exception to use for %r" % e) from e
+        return wrapper
+    return decorator

--- a/tests/decorator-utils/test_replace_exceptions.py
+++ b/tests/decorator-utils/test_replace_exceptions.py
@@ -1,0 +1,32 @@
+import pytest
+
+from eth_utils.decorators import replace_exceptions
+
+
+class ValidationError(Exception):
+    pass
+
+
+class BlockNotFound(Exception):
+    pass
+
+    
+@pytest.fixture()
+def mock_function_with_exception(old_to_new):
+    @replace_exceptions(old_to_new)
+    def function_with_exception(val=True):
+        raise BlockNotFound
+    return function_with_exception
+
+
+@pytest.mark.parametrize(
+    'old_to_new, new',
+    (
+        ({BlockNotFound: ValidationError}, ValidationError),
+        ({BlockNotFound: TypeError}, TypeError),
+        ({ValidationError: BlockNotFound, BlockNotFound: TypeError}, TypeError),
+    )
+)
+def test_decorator_replaces_exceptions(mock_function_with_exception, old_to_new, new):
+    with pytest.raises(new):
+        mock_function_with_exception(old_to_new)


### PR DESCRIPTION
### What was wrong?
Eth-utils is a good place for the `replace_exceptions` decorator as it's used across multiple libraries

### How was it fixed?
Moved the `replace_exceptions` decorator form `eth-tester.formatting` to `decorators` module here.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/40329429-c960a5f6-5d06-11e8-9082-54d6db89b955.png)
