### PR TITLE
readme: is_hex() raises on bytes argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1157,16 +1157,10 @@ Returns `True` if `value` is a hexadecimal encoded string of text type.
 ```python
 >>> is_hex('')
 False
->>> is_hex(b'')
-False
 >>> is_hex('0x')
 True
->>> is_hex(b'0x')
-False
 >>> is_hex('0X')
 True
->>> is_hex(b'0X')
-False
 >>> is_hex('1234567890abcdef')
 True
 >>> is_hex('0x1234567890abcdef')
@@ -1181,6 +1175,11 @@ True
 True
 >>> is_hex('123456__abcdef')  # non hex characters
 False
+
+# invalid, will raise TypeError:
+>>> is_hex(b'')
+>>> is_hex(b'0x')
+>>> is_hex(b'0X')
 ```
 
 #### `remove_0x_prefix(value)` -> string


### PR DESCRIPTION
### What was wrong?

Fixes #104 

### How was it fixed?

Note that `is_hex(bytes_val)` will raise exception, in readme

#### Cute Animal Picture

![Cute animal picture](https://scontent.fsnc1-1.fna.fbcdn.net/v/t1.0-9/22007445_1377810075668700_9036043124441478317_n.jpg?_nc_cat=0&oh=6a9c37471883724d44d1684c7172a613&oe=5B7B67AB)
