### PR TITLE
Add import_string util from django

### DIFF
--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -74,6 +74,9 @@ from .hexadecimal import (  # noqa: F401
     is_hex,
     remove_0x_prefix,
 )
+from .module_loading import (  # noqa: F401
+    import_string,
+)
 from .types import (  # noqa: F401
     is_boolean,
     is_bytes,

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -26,6 +26,7 @@ from eth_utils import (
     function_abi_to_4byte_selector,
     function_signature_to_4byte_selector,
     hexstr_if_str,
+    import_string,
     int_to_big_endian,
     is_0x_prefixed,
     is_address,

--- a/eth_utils/module_loading.py
+++ b/eth_utils/module_loading.py
@@ -1,0 +1,25 @@
+from importlib import import_module
+
+from typing import Any
+
+
+def import_string(dotted_path: str) -> Any:
+    """
+    Source: django.utils.module_loading
+    Import a dotted module path and return the attribute/class designated by the
+    last name in the path. Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit('.', 1)
+    except ValueError:
+        msg = "%s doesn't look like a module path" % dotted_path
+        raise ImportError(msg)
+
+    module = import_module(module_path)
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError:
+        msg = 'Module "%s" does not define a "%s" attribute/class' % (
+            module_path, class_name)
+        raise ImportError(msg)

--- a/tests/module-loading-utils/test_import_string.py
+++ b/tests/module-loading-utils/test_import_string.py
@@ -1,0 +1,10 @@
+from eth_utils.decorators import (
+    combomethod,
+)
+from eth_utils.module_loading import (
+    import_string,
+)
+
+def test_import_string():
+    imported_combomethod = import_string('eth_utils.decorators.combomethod')
+    assert imported_combomethod is combomethod


### PR DESCRIPTION
### What was wrong?
This util is both used in `py-evm` and `py-ethpm` - so @cburgdorf suggested moving it to a shared location here.

### How was it fixed?
Added the util to `module_loading.py`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/42000401-c8e970e2-7a1d-11e8-986a-eb8751b32081.png)
