### PR TITLE
Write ValidationError exception

### DIFF
--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -55,6 +55,9 @@ from .encoding import (  # noqa: F401
     big_endian_to_int,
     int_to_big_endian,
 )
+from .exceptions import (  # noqa: F401
+    ValidationError,
+)
 from .functional import (  # noqa: F401
     apply_to_return_value,
     flatten_return,

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -66,6 +66,7 @@ from eth_utils import (
     to_text,
     to_tuple,
     to_wei,
+    ValidationError,
 )
 
 apply_formatter_at_index = curry(apply_formatter_at_index)

--- a/eth_utils/exceptions.py
+++ b/eth_utils/exceptions.py
@@ -1,0 +1,5 @@
+class ValidationError(Exception):
+    """
+    Raised when something does not pass a validation check.
+    """
+    pass

--- a/tests/curried-utils/test_curried.py
+++ b/tests/curried-utils/test_curried.py
@@ -46,6 +46,8 @@ def test_curried_namespace():
     def should_curry(func):
         if not callable(func) or isinstance(func, curry):
             return False
+        if isinstance(func, type) and issubclass(func, Exception):
+            return False
         nargs = enhanced_num_required_args(func)
         if nargs is None or nargs > 1:
             return True


### PR DESCRIPTION
### What was wrong?
Libraries need a common `ValidationError` exception.


### How was it fixed?
Added `ValidationError` to new `exceptions` module

fixes #114 

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/44035035-236ecb0e-9ed4-11e8-98f2-f895070c1f4b.png)

