### PR TITLE
Update eth-typing version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
-        "eth-typing>=1.0.0,<2.0.0",
+        "eth-typing>=1.1.0,<2.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",
         "cytoolz>=0.8.2,<1.0.0;implementation_name=='cpython'",
     ],


### PR DESCRIPTION
### What was wrong?
When I updated `py-ethpm` to use eth-utils `v1.1.1`, it installs eth-typing `v1.0.0` even though eth-typing is pinned to `>=1.1.0` in py-ethpm. 


### How was it fixed?
pin eth-typing dependency to `>=1.1.0`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/44179150-abb21e00-a0b2-11e8-83f7-664cae5b745d.png)
