### PR TITLE
Update eth-typing version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
-        "eth-typing>=1.1.0,<2.0.0",
+        "eth-typing>=1.3.0,<2.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",
         "cytoolz>=0.8.2,<1.0.0;implementation_name=='cpython'",
     ],


### PR DESCRIPTION
### What was wrong?
If I'm not mistaken, this update should finally correct the weird dependency bugs b/w `eth-utils` and `eth-typing` seen [here](https://github.com/ethpm/py-ethpm/pull/87). 

If someone with write access can cut a new release soon after this gets merged, that'd be super to see if the problem's been resolved.


### How was it fixed?
Updated `eth-typing` version.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/44665958-85568180-a9d4-11e8-9146-3e3757a21f54.png)

