### PR TITLE
Constraining Python Version 3.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "cytoolz>=0.8.2,<1.0.0;implementation_name=='cpython'",
     ],
     setup_requires=['setuptools-markdown'],
+    python_requires='>=3.5,!=3.5.2,<4',
     extras_require=extras_require,
     py_modules=['eth_utils'],
     license="MIT",


### PR DESCRIPTION
Solves #125

### What was wrong?

See ethereum/web3.py#1012 (comment)

Python 3.5.2 has a bug...

### How was it fixed?

Added requirement string which excludes 3.5.2

#### Cute Animal Picture

![Cute animal picture]()
