### PR TITLE
Add black to linting environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,10 @@ common: &common
           fi
     - restore_cache:
         keys:
-          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - v1-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: upgrade pip
+        command: pip install --upgrade pip
     - run:
         name: install dependencies
         command: pip install --user tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
         environment:
           TOXENV: lint
   py35:

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -39,25 +39,11 @@ from .conversions import (  # noqa: F401
     hexstr_if_str,
     text_if_str,
 )
-from .crypto import (  # noqa: F401
-    keccak,
-)
-from .currency import (  # noqa: F401
-    denoms,
-    from_wei,
-    to_wei,
-)
-from .decorators import (  # noqa: F401
-    combomethod,
-    replace_exceptions,
-)
-from .encoding import (  # noqa: F401
-    big_endian_to_int,
-    int_to_big_endian,
-)
-from .exceptions import (  # noqa: F401
-    ValidationError,
-)
+from .crypto import keccak  # noqa: F401
+from .currency import denoms, from_wei, to_wei  # noqa: F401
+from .decorators import combomethod, replace_exceptions  # noqa: F401
+from .encoding import big_endian_to_int, int_to_big_endian  # noqa: F401
+from .exceptions import ValidationError  # noqa: F401
 from .functional import (  # noqa: F401
     apply_to_return_value,
     flatten_return,
@@ -77,9 +63,7 @@ from .hexadecimal import (  # noqa: F401
     is_hex,
     remove_0x_prefix,
 )
-from .module_loading import (  # noqa: F401
-    import_string,
-)
+from .module_loading import import_string  # noqa: F401
 from .types import (  # noqa: F401
     is_boolean,
     is_bytes,
@@ -96,10 +80,12 @@ from .types import (  # noqa: F401
 
 
 if sys.version_info.major < 3:
-    warnings.simplefilter('always', DeprecationWarning)
-    warnings.warn(DeprecationWarning(
-        "The `eth-utils` library has dropped support for Python 2. Upgrade to Python 3."
-    ))
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        DeprecationWarning(
+            "The `eth-utils` library has dropped support for Python 2. Upgrade to Python 3."
+        )
+    )
     warnings.resetwarnings()
 
 

--- a/eth_utils/__main__.py
+++ b/eth_utils/__main__.py
@@ -1,5 +1,3 @@
-from .debug import (
-    get_environment_summary,
-)
+from .debug import get_environment_summary
 
 print(get_environment_summary())

--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -1,23 +1,18 @@
-from typing import (
-    Any,
-    Dict,
-)
+from typing import Any, Dict
 
 from .crypto import keccak
 
 
 def _abi_to_signature(abi: Dict[str, Any]) -> str:
     function_signature = "{fn_name}({fn_input_types})".format(
-        fn_name=abi['name'],
-        fn_input_types=','.join([
-            arg['type'] for arg in abi.get('inputs', [])
-        ]),
+        fn_name=abi["name"],
+        fn_input_types=",".join([arg["type"] for arg in abi.get("inputs", [])]),
     )
     return function_signature
 
 
 def function_signature_to_4byte_selector(event_signature: str) -> bytes:
-    return keccak(text=event_signature.replace(' ', ''))[:4]
+    return keccak(text=event_signature.replace(" ", ""))[:4]
 
 
 def function_abi_to_4byte_selector(function_abi: Dict[str, Any]) -> bytes:
@@ -26,7 +21,7 @@ def function_abi_to_4byte_selector(function_abi: Dict[str, Any]) -> bytes:
 
 
 def event_signature_to_log_topic(event_signature: str) -> bytes:
-    return keccak(text=event_signature.replace(' ', ''))
+    return keccak(text=event_signature.replace(" ", ""))
 
 
 def event_abi_to_log_topic(event_abi: Dict[str, Any]) -> bytes:

--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -1,30 +1,10 @@
-from typing import (
-    Any,
-    AnyStr,
-)
+from typing import Any, AnyStr
 
 from .crypto import keccak
-from .hexadecimal import (
-    add_0x_prefix,
-    decode_hex,
-    encode_hex,
-    is_hex,
-    remove_0x_prefix,
-)
-from .conversions import (
-    hexstr_if_str,
-    to_hex,
-)
-from .types import (
-    is_bytes,
-    is_text,
-)
-from .typing import (
-    Address,
-    AnyAddress,
-    ChecksumAddress,
-    HexAddress,
-)
+from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hex, remove_0x_prefix
+from .conversions import hexstr_if_str, to_hex
+from .types import is_bytes, is_text
+from .typing import Address, AnyAddress, ChecksumAddress, HexAddress
 
 
 def is_hex_address(value: Any) -> bool:
@@ -129,14 +109,16 @@ def to_checksum_address(value: AnyStr) -> ChecksumAddress:
     norm_address = to_normalized_address(value)
     address_hash = encode_hex(keccak(text=remove_0x_prefix(norm_address)))
 
-    checksum_address = add_0x_prefix(''.join(
-        (
-            norm_address[i].upper()
-            if int(address_hash[i], 16) > 7
-            else norm_address[i]
+    checksum_address = add_0x_prefix(
+        "".join(
+            (
+                norm_address[i].upper()
+                if int(address_hash[i], 16) > 7
+                else norm_address[i]
+            )
+            for i in range(2, 42)
         )
-        for i in range(2, 42)
-    ))
+    )
     return ChecksumAddress(HexAddress(checksum_address))
 
 

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,33 +1,19 @@
 import warnings
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    List,
-    Tuple,
-)
+from typing import Any, Callable, Dict, Generator, List, Tuple
 
-from .toolz import (
-    compose,
-    curry
-)
-from .decorators import (
-    return_arg_type,
-)
-from .functional import (
-    to_dict,
-)
+from .toolz import compose, curry
+from .decorators import return_arg_type
+from .functional import to_dict
 
 
 Formatters = Callable[[List[Any]], List[Any]]
 
 
 @return_arg_type(2)
-def apply_formatter_at_index(formatter: Callable[..., Any],
-                             at_index: int,
-                             value: List[Any]) -> Generator[List[Any], None, None]:
+def apply_formatter_at_index(
+    formatter: Callable[..., Any], at_index: int, value: List[Any]
+) -> Generator[List[Any], None, None]:
     if at_index + 1 > len(value):
         raise IndexError(
             "Not enough values in iterable to apply formatter.  Got: {0}. "
@@ -41,43 +27,49 @@ def apply_formatter_at_index(formatter: Callable[..., Any],
 
 
 def combine_argument_formatters(*formatters: List[Callable[..., Any]]) -> Formatters:
-    warnings.warn(DeprecationWarning(
-        "combine_argument_formatters(formatter1, formatter2)([item1, item2])"
-        "has been deprecated and will be removed in a subsequent major version "
-        "release of the eth-utils library. Update your calls to use "
-        "apply_formatters_to_sequence([formatter1, formatter2], [item1, item2]) "
-        "instead."
-    ))
+    warnings.warn(
+        DeprecationWarning(
+            "combine_argument_formatters(formatter1, formatter2)([item1, item2])"
+            "has been deprecated and will be removed in a subsequent major version "
+            "release of the eth-utils library. Update your calls to use "
+            "apply_formatters_to_sequence([formatter1, formatter2], [item1, item2]) "
+            "instead."
+        )
+    )
 
     _formatter_at_index = curry(apply_formatter_at_index)
-    return compose(*(
-        _formatter_at_index(formatter, index)
-        for index, formatter
-        in enumerate(formatters)
-    ))
+    return compose(
+        *(
+            _formatter_at_index(formatter, index)
+            for index, formatter in enumerate(formatters)
+        )
+    )
 
 
 @return_arg_type(1)
-def apply_formatters_to_sequence(formatters: List[Any],
-                                 sequence: List[Any]) -> Generator[List[Any], None, None]:
+def apply_formatters_to_sequence(
+    formatters: List[Any], sequence: List[Any]
+) -> Generator[List[Any], None, None]:
     if len(formatters) > len(sequence):
-        raise IndexError("Too many formatters for sequence: {} formatters for {!r}".format(
-            len(formatters),
-            sequence,
-        ))
+        raise IndexError(
+            "Too many formatters for sequence: {} formatters for {!r}".format(
+                len(formatters), sequence
+            )
+        )
     elif len(formatters) < len(sequence):
-        raise IndexError("Too few formatters for sequence: {} formatters for {!r}".format(
-            len(formatters),
-            sequence,
-        ))
+        raise IndexError(
+            "Too few formatters for sequence: {} formatters for {!r}".format(
+                len(formatters), sequence
+            )
+        )
     else:
         for formatter, item in zip(formatters, sequence):
             yield formatter(item)
 
 
-def apply_formatter_if(condition: Callable[..., Any],
-                       formatter: Callable[..., Any],
-                       value: Any) -> Any:
+def apply_formatter_if(
+    condition: Callable[..., Any], formatter: Callable[..., Any], value: Any
+) -> Any:
     if condition(value):
         return formatter(value)
     else:
@@ -85,51 +77,56 @@ def apply_formatter_if(condition: Callable[..., Any],
 
 
 @to_dict
-def apply_formatters_to_dict(formatters: Dict[Any, Any],
-                             value: Dict[Any, Any]) -> Generator[Tuple[Any, Any], None, None]:
+def apply_formatters_to_dict(
+    formatters: Dict[Any, Any], value: Dict[Any, Any]
+) -> Generator[Tuple[Any, Any], None, None]:
     for key, item in value.items():
         if key in formatters:
             try:
                 yield key, formatters[key](item)
             except (TypeError, ValueError) as exc:
-                raise type(exc)("Could not format value %r as field %r" % (item, key)) from exc
+                raise type(exc)(
+                    "Could not format value %r as field %r" % (item, key)
+                ) from exc
         else:
             yield key, item
 
 
 @return_arg_type(1)
-def apply_formatter_to_array(formatter: Callable[..., Any],
-                             value: List[Any]) -> Generator[List[Any], None, None]:
+def apply_formatter_to_array(
+    formatter: Callable[..., Any], value: List[Any]
+) -> Generator[List[Any], None, None]:
     for item in value:
         yield formatter(item)
 
 
 def apply_one_of_formatters(
-        formatter_condition_pairs: Tuple[Tuple[Callable[..., Any], Callable[..., Any]]],
-        value: Any) -> Any:
+    formatter_condition_pairs: Tuple[Tuple[Callable[..., Any], Callable[..., Any]]],
+    value: Any,
+) -> Any:
     for condition, formatter in formatter_condition_pairs:
         if condition(value):
             return formatter(value)
     else:
-        raise ValueError("The provided value did not satisfy any of the formatter conditions")
+        raise ValueError(
+            "The provided value did not satisfy any of the formatter conditions"
+        )
 
 
 @to_dict
-def apply_key_map(key_mappings: Dict[Any, Any],
-                  value: Dict[Any, Any]) -> Generator[Tuple[Any, Any], None, None]:
-    key_conflicts = set(
-        value.keys()
-    ).difference(
-        key_mappings.keys()
-    ).intersection(
-        v
-        for k, v
-        in key_mappings.items()
-        if v in value
+def apply_key_map(
+    key_mappings: Dict[Any, Any], value: Dict[Any, Any]
+) -> Generator[Tuple[Any, Any], None, None]:
+    key_conflicts = (
+        set(value.keys())
+        .difference(key_mappings.keys())
+        .intersection(v for k, v in key_mappings.items() if v in value)
     )
     if key_conflicts:
         raise KeyError(
-            "Could not apply key map due to conflicting key(s): {}".format(key_conflicts)
+            "Could not apply key map due to conflicting key(s): {}".format(
+                key_conflicts
+            )
         )
 
     for key, item in value.items():

--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -1,36 +1,16 @@
-from typing import (
-    Callable,
-    Union,
-)
+from typing import Callable, Union
 
-from .decorators import (
-    validate_conversion_arguments,
-)
-from .encoding import (
-    big_endian_to_int,
-    int_to_big_endian,
-)
-from .hexadecimal import (
-    add_0x_prefix,
-    decode_hex,
-    encode_hex,
-    is_hex,
-    remove_0x_prefix,
-)
-from .types import (
-    is_boolean,
-    is_integer,
-    is_string,
-)
-from .typing import (
-    HexStr,
-    Primitives,
-    T,
-)
+from .decorators import validate_conversion_arguments
+from .encoding import big_endian_to_int, int_to_big_endian
+from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hex, remove_0x_prefix
+from .types import is_boolean, is_integer, is_string
+from .typing import HexStr, Primitives, T
 
 
 @validate_conversion_arguments
-def to_hex(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> HexStr:
+def to_hex(
+    primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+) -> HexStr:
     """
     Auto converts any supported value into its hex representation.
     Trims leading zeros, as defined in:
@@ -40,7 +20,7 @@ def to_hex(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> H
         return HexStr(add_0x_prefix(hexstr.lower()))
 
     if text is not None:
-        return HexStr(encode_hex(text.encode('utf-8')))
+        return HexStr(encode_hex(text.encode("utf-8")))
 
     if is_boolean(primitive):
         return HexStr("0x1") if primitive else HexStr("0x0")
@@ -63,7 +43,9 @@ def to_hex(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> H
 
 
 @validate_conversion_arguments
-def to_int(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> int:
+def to_int(
+    primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+) -> int:
     """
     Converts value to its integer representation.
     Values are converted this way:
@@ -86,9 +68,11 @@ def to_int(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> i
 
 
 @validate_conversion_arguments
-def to_bytes(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> bytes:
+def to_bytes(
+    primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+) -> bytes:
     if is_boolean(primitive):
-        return b'\x01' if primitive else b'\x00'
+        return b"\x01" if primitive else b"\x00"
     elif isinstance(primitive, bytearray):
         return bytes(primitive)
     elif isinstance(primitive, bytes):
@@ -98,38 +82,42 @@ def to_bytes(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) ->
     elif hexstr is not None:
         if len(hexstr) % 2:
             # type check ignored here because casting an Optional arg to str is not possible
-            hexstr = '0x0' + remove_0x_prefix(hexstr)  # type: ignore
+            hexstr = "0x0" + remove_0x_prefix(hexstr)  # type: ignore
         return decode_hex(hexstr)
     elif text is not None:
-        return text.encode('utf-8')
+        return text.encode("utf-8")
     raise TypeError(
         "expected a bool, int, byte or bytearray in first arg, or keyword of hexstr or text"
     )
 
 
 @validate_conversion_arguments
-def to_text(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> str:
+def to_text(
+    primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+) -> str:
     if hexstr is not None:
-        return to_bytes(hexstr=hexstr).decode('utf-8')
+        return to_bytes(hexstr=hexstr).decode("utf-8")
     elif text is not None:
         return text
     elif isinstance(primitive, str):
         return to_text(hexstr=primitive)
     elif isinstance(primitive, (bytes, bytearray)):
-        return primitive.decode('utf-8')
+        return primitive.decode("utf-8")
     elif is_integer(primitive):
         byte_encoding = int_to_big_endian(primitive)
         return to_text(byte_encoding)
     raise TypeError("Expected an int, bytes, bytearray or hexstr.")
 
 
-def text_if_str(to_type: Callable[..., T], text_or_primitive: Union[bytes, int, str]) -> T:
-    '''
+def text_if_str(
+    to_type: Callable[..., T], text_or_primitive: Union[bytes, int, str]
+) -> T:
+    """
     Convert to a type, assuming that strings can be only unicode text (not a hexstr)
     @param to_type is a function that takes the arguments (primitive, hexstr=hexstr, text=text),
         eg~ to_bytes, to_text, to_hex, to_int, etc
     @param text_or_primitive in bytes, str, or int.
-    '''
+    """
     if isinstance(text_or_primitive, str):
         (primitive, text) = (None, text_or_primitive)
     else:
@@ -137,19 +125,21 @@ def text_if_str(to_type: Callable[..., T], text_or_primitive: Union[bytes, int, 
     return to_type(primitive, text=text)
 
 
-def hexstr_if_str(to_type: Callable[..., T], hexstr_or_primitive: Union[bytes, int, str]) -> T:
-    '''
+def hexstr_if_str(
+    to_type: Callable[..., T], hexstr_or_primitive: Union[bytes, int, str]
+) -> T:
+    """
     Convert to a type, assuming that strings can be only hexstr (not unicode text)
     @param to_type is a function that takes the arguments (primitive, hexstr=hexstr, text=text),
         eg~ to_bytes, to_text, to_hex, to_int, etc
     @param hexstr_or_primitive in bytes, str, or int.
-    '''
+    """
     if isinstance(hexstr_or_primitive, str):
         (primitive, hexstr) = (None, hexstr_or_primitive)
         if remove_0x_prefix(hexstr) and not is_hex(hexstr):
             raise ValueError(
                 "when sending a str, it must be a hex string. Got: {0!r}".format(
-                    hexstr_or_primitive,
+                    hexstr_or_primitive
                 )
             )
     else:

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -2,10 +2,10 @@ from typing import Union
 
 from eth_hash.auto import keccak as keccak_256
 
-from .conversions import (
-    to_bytes,
-)
+from .conversions import to_bytes
 
 
-def keccak(primitive: Union[bytes, int, bool]=None, hexstr: str=None, text: str=None) -> bytes:
+def keccak(
+    primitive: Union[bytes, int, bool] = None, hexstr: str = None, text: str = None
+) -> bytes:
     return keccak_256(to_bytes(primitive, hexstr, text))

--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -4,33 +4,7 @@ from decimal import localcontext
 from typing import Union
 
 from .types import is_integer, is_string
-
-
-units = {
-    "wei": decimal.Decimal("1"),  # noqa: E241
-    "kwei": decimal.Decimal("1000"),  # noqa: E241
-    "babbage": decimal.Decimal("1000"),  # noqa: E241
-    "femtoether": decimal.Decimal("1000"),  # noqa: E241
-    "mwei": decimal.Decimal("1000000"),  # noqa: E241
-    "lovelace": decimal.Decimal("1000000"),  # noqa: E241
-    "picoether": decimal.Decimal("1000000"),  # noqa: E241
-    "gwei": decimal.Decimal("1000000000"),  # noqa: E241
-    "shannon": decimal.Decimal("1000000000"),  # noqa: E241
-    "nanoether": decimal.Decimal("1000000000"),  # noqa: E241
-    "nano": decimal.Decimal("1000000000"),  # noqa: E241
-    "szabo": decimal.Decimal("1000000000000"),  # noqa: E241
-    "microether": decimal.Decimal("1000000000000"),  # noqa: E241
-    "micro": decimal.Decimal("1000000000000"),  # noqa: E241
-    "finney": decimal.Decimal("1000000000000000"),  # noqa: E241
-    "milliether": decimal.Decimal("1000000000000000"),  # noqa: E241
-    "milli": decimal.Decimal("1000000000000000"),  # noqa: E241
-    "ether": decimal.Decimal("1000000000000000000"),  # noqa: E241
-    "kether": decimal.Decimal("1000000000000000000000"),  # noqa: E241
-    "grand": decimal.Decimal("1000000000000000000000"),  # noqa: E241
-    "mether": decimal.Decimal("1000000000000000000000000"),  # noqa: E241
-    "gether": decimal.Decimal("1000000000000000000000000000"),  # noqa: E241
-    "tether": decimal.Decimal("1000000000000000000000000000000"),  # noqa: E241
-}
+from .units import units
 
 
 denoms = type("denoms", (object,), {key: int(value) for key, value in units.items()})

--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -3,42 +3,37 @@ from decimal import localcontext
 
 from typing import Union
 
-from .types import (
-    is_integer,
-    is_string,
-)
+from .types import is_integer, is_string
 
 
 units = {
-    'wei':          decimal.Decimal('1'),  # noqa: E241
-    'kwei':         decimal.Decimal('1000'),  # noqa: E241
-    'babbage':      decimal.Decimal('1000'),  # noqa: E241
-    'femtoether':   decimal.Decimal('1000'),  # noqa: E241
-    'mwei':         decimal.Decimal('1000000'),  # noqa: E241
-    'lovelace':     decimal.Decimal('1000000'),  # noqa: E241
-    'picoether':    decimal.Decimal('1000000'),  # noqa: E241
-    'gwei':         decimal.Decimal('1000000000'),  # noqa: E241
-    'shannon':      decimal.Decimal('1000000000'),  # noqa: E241
-    'nanoether':    decimal.Decimal('1000000000'),  # noqa: E241
-    'nano':         decimal.Decimal('1000000000'),  # noqa: E241
-    'szabo':        decimal.Decimal('1000000000000'),  # noqa: E241
-    'microether':   decimal.Decimal('1000000000000'),  # noqa: E241
-    'micro':        decimal.Decimal('1000000000000'),  # noqa: E241
-    'finney':       decimal.Decimal('1000000000000000'),  # noqa: E241
-    'milliether':   decimal.Decimal('1000000000000000'),  # noqa: E241
-    'milli':        decimal.Decimal('1000000000000000'),  # noqa: E241
-    'ether':        decimal.Decimal('1000000000000000000'),  # noqa: E241
-    'kether':       decimal.Decimal('1000000000000000000000'),  # noqa: E241
-    'grand':        decimal.Decimal('1000000000000000000000'),  # noqa: E241
-    'mether':       decimal.Decimal('1000000000000000000000000'),  # noqa: E241
-    'gether':       decimal.Decimal('1000000000000000000000000000'),  # noqa: E241
-    'tether':       decimal.Decimal('1000000000000000000000000000000'),  # noqa: E241
+    "wei": decimal.Decimal("1"),  # noqa: E241
+    "kwei": decimal.Decimal("1000"),  # noqa: E241
+    "babbage": decimal.Decimal("1000"),  # noqa: E241
+    "femtoether": decimal.Decimal("1000"),  # noqa: E241
+    "mwei": decimal.Decimal("1000000"),  # noqa: E241
+    "lovelace": decimal.Decimal("1000000"),  # noqa: E241
+    "picoether": decimal.Decimal("1000000"),  # noqa: E241
+    "gwei": decimal.Decimal("1000000000"),  # noqa: E241
+    "shannon": decimal.Decimal("1000000000"),  # noqa: E241
+    "nanoether": decimal.Decimal("1000000000"),  # noqa: E241
+    "nano": decimal.Decimal("1000000000"),  # noqa: E241
+    "szabo": decimal.Decimal("1000000000000"),  # noqa: E241
+    "microether": decimal.Decimal("1000000000000"),  # noqa: E241
+    "micro": decimal.Decimal("1000000000000"),  # noqa: E241
+    "finney": decimal.Decimal("1000000000000000"),  # noqa: E241
+    "milliether": decimal.Decimal("1000000000000000"),  # noqa: E241
+    "milli": decimal.Decimal("1000000000000000"),  # noqa: E241
+    "ether": decimal.Decimal("1000000000000000000"),  # noqa: E241
+    "kether": decimal.Decimal("1000000000000000000000"),  # noqa: E241
+    "grand": decimal.Decimal("1000000000000000000000"),  # noqa: E241
+    "mether": decimal.Decimal("1000000000000000000000000"),  # noqa: E241
+    "gether": decimal.Decimal("1000000000000000000000000000"),  # noqa: E241
+    "tether": decimal.Decimal("1000000000000000000000000000000"),  # noqa: E241
 }
 
 
-denoms = type('denoms', (object,), {
-    key: int(value) for key, value in units.items()
-})
+denoms = type("denoms", (object,), {key: int(value) for key, value in units.items()})
 
 
 MIN_WEI = 0
@@ -51,7 +46,7 @@ def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
     """
     if unit.lower() not in units:
         raise ValueError(
-            "Unknown unit.  Must be one of {0}".format('/'.join(units.keys()))
+            "Unknown unit.  Must be one of {0}".format("/".join(units.keys()))
         )
 
     if number == 0:
@@ -76,7 +71,7 @@ def to_wei(number: int, unit: str) -> int:
     """
     if unit.lower() not in units:
         raise ValueError(
-            "Unknown unit.  Must be one of {0}".format('/'.join(units.keys()))
+            "Unknown unit.  Must be one of {0}".format("/".join(units.keys()))
         )
 
     if is_integer(number) or is_string(number):
@@ -94,12 +89,12 @@ def to_wei(number: int, unit: str) -> int:
     if d_number == 0:
         return 0
 
-    if d_number < 1 and '.' in s_number:
+    if d_number < 1 and "." in s_number:
         with localcontext() as ctx:
-            multiplier = len(s_number) - s_number.index('.') - 1
+            multiplier = len(s_number) - s_number.index(".") - 1
             ctx.prec = multiplier
-            d_number = decimal.Decimal(value=number, context=ctx) * 10**multiplier
-        unit_value /= 10**multiplier
+            d_number = decimal.Decimal(value=number, context=ctx) * 10 ** multiplier
+        unit_value /= 10 ** multiplier
 
     with localcontext() as ctx:
         ctx.prec = 999

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -1,7 +1,5 @@
 # flake8: noqa
-from eth_utils.toolz import (
-    curry,
-)
+from eth_utils.toolz import curry
 
 from eth_utils import (
     add_0x_prefix,

--- a/eth_utils/debug.py
+++ b/eth_utils/debug.py
@@ -4,7 +4,7 @@ import sys
 
 
 def pip_freeze() -> str:
-    result = subprocess.run('pip freeze'.split(), stdout=subprocess.PIPE)
+    result = subprocess.run("pip freeze".split(), stdout=subprocess.PIPE)
     return "pip freeze result:\n%s" % result.stdout.decode()
 
 
@@ -17,8 +17,4 @@ def platform_info() -> str:
 
 
 def get_environment_summary() -> str:
-    return '\n\n'.join([
-        python_version(),
-        platform_info(),
-        pip_freeze(),
-    ])
+    return "\n\n".join([python_version(), platform_info(), pip_freeze()])

--- a/eth_utils/encoding.py
+++ b/eth_utils/encoding.py
@@ -1,6 +1,6 @@
 def int_to_big_endian(value: int) -> bytes:
-    return value.to_bytes((value.bit_length() + 7) // 8 or 1, 'big')
+    return value.to_bytes((value.bit_length() + 7) // 8 or 1, "big")
 
 
 def big_endian_to_int(value: bytes) -> int:
-    return int.from_bytes(value, 'big')
+    return int.from_bytes(value, "big")

--- a/eth_utils/exceptions.py
+++ b/eth_utils/exceptions.py
@@ -2,4 +2,5 @@ class ValidationError(Exception):
     """
     Raised when something does not pass a validation check.
     """
+
     pass

--- a/eth_utils/functional.py
+++ b/eth_utils/functional.py
@@ -2,9 +2,7 @@ import collections
 import functools
 import itertools
 
-from .toolz import (
-    compose as _compose,
-)
+from .toolz import compose as _compose
 
 
 def identity(value):
@@ -22,6 +20,7 @@ def apply_to_return_value(callback):
             return callback(fn(*args, **kwargs))
 
         return inner
+
     return outer
 
 
@@ -31,5 +30,7 @@ to_dict = apply_to_return_value(dict)
 to_ordered_dict = apply_to_return_value(collections.OrderedDict)
 to_set = apply_to_return_value(set)
 sort_return = _compose(to_tuple, apply_to_return_value(sorted))
-flatten_return = _compose(to_tuple, apply_to_return_value(itertools.chain.from_iterable))
+flatten_return = _compose(
+    to_tuple, apply_to_return_value(itertools.chain.from_iterable)
+)
 reversed_return = _compose(to_tuple, apply_to_return_value(reversed), to_tuple)

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -4,30 +4,24 @@ import binascii
 import codecs
 import string
 
-from typing import (
-    Any,
-    AnyStr,
-)
+from typing import Any, AnyStr
 
-from .types import (
-    is_string,
-    is_text,
-)
+from .types import is_string, is_text
 
 
 # Type ignored for `codecs.decode()` due to lack of mypy support for 'hex' encoding
 # https://github.com/python/typeshed/issues/300
 def decode_hex(value: str) -> bytes:
     if not is_text(value):
-        raise TypeError('Value must be an instance of str')
-    return codecs.decode(remove_0x_prefix(value), 'hex')  # type: ignore
+        raise TypeError("Value must be an instance of str")
+    return codecs.decode(remove_0x_prefix(value), "hex")  # type: ignore
 
 
 def encode_hex(value: AnyStr) -> str:
     if not is_string(value):
-        raise TypeError('Value must be an instance of str or unicode')
-    binary_hex = codecs.encode(value, 'hex')  # type: ignore
-    return add_0x_prefix(binary_hex.decode('ascii'))
+        raise TypeError("Value must be an instance of str or unicode")
+    binary_hex = codecs.encode(value, "hex")  # type: ignore
+    return add_0x_prefix(binary_hex.decode("ascii"))
 
 
 def is_0x_prefixed(value: Any) -> bool:
@@ -35,7 +29,7 @@ def is_0x_prefixed(value: Any) -> bool:
         raise TypeError(
             "is_0x_prefixed requires text typed arguments. Got: {0}".format(repr(value))
         )
-    return value.startswith('0x') or value.startswith('0X')
+    return value.startswith("0x") or value.startswith("0X")
 
 
 def remove_0x_prefix(value: str) -> str:
@@ -47,18 +41,20 @@ def remove_0x_prefix(value: str) -> str:
 def add_0x_prefix(value: str) -> str:
     if is_0x_prefixed(value):
         return value
-    return '0x' + value
+    return "0x" + value
 
 
 def is_hex(value: Any) -> bool:
     if not is_text(value):
-        raise TypeError('is_hex requires text typed arguments. Got: {0}'.format(repr(value)))
-    elif value.lower() == '0x':
+        raise TypeError(
+            "is_hex requires text typed arguments. Got: {0}".format(repr(value))
+        )
+    elif value.lower() == "0x":
         return True
 
     unprefixed_value = remove_0x_prefix(value)
     if len(unprefixed_value) % 2 != 0:
-        value_to_decode = '0' + unprefixed_value
+        value_to_decode = "0" + unprefixed_value
     else:
         value_to_decode = unprefixed_value
 
@@ -66,7 +62,7 @@ def is_hex(value: Any) -> bool:
         return False
 
     try:
-        value_as_bytes = codecs.decode(value_to_decode, 'hex')  # type: ignore
+        value_as_bytes = codecs.decode(value_to_decode, "hex")  # type: ignore
     except binascii.Error:
         return False
     except TypeError:

--- a/eth_utils/module_loading.py
+++ b/eth_utils/module_loading.py
@@ -10,7 +10,7 @@ def import_string(dotted_path: str) -> Any:
     last name in the path. Raise ImportError if the import failed.
     """
     try:
-        module_path, class_name = dotted_path.rsplit('.', 1)
+        module_path, class_name = dotted_path.rsplit(".", 1)
     except ValueError:
         msg = "%s doesn't look like a module path" % dotted_path
         raise ImportError(msg)
@@ -21,5 +21,7 @@ def import_string(dotted_path: str) -> Any:
         return getattr(module, class_name)
     except AttributeError:
         msg = 'Module "%s" does not define a "%s" attribute/class' % (
-            module_path, class_name)
+            module_path,
+            class_name,
+        )
         raise ImportError(msg)

--- a/eth_utils/typing/misc.py
+++ b/eth_utils/typing/misc.py
@@ -1,15 +1,13 @@
-from typing import (
-    NewType,
-    TypeVar,
-    Union,
-)
+from typing import NewType, TypeVar, Union
 
 from eth_typing import Address
 
 
-HexAddress = NewType('HexAddress', str)  # for hex encoded addresses
-ChecksumAddress = NewType('ChecksumAddress', HexAddress)  # for hex addresses with checksums
-AnyAddress = TypeVar('AnyAddress', Address, HexAddress, ChecksumAddress)
-HexStr = NewType('HexStr', str)
+HexAddress = NewType("HexAddress", str)  # for hex encoded addresses
+ChecksumAddress = NewType(
+    "ChecksumAddress", HexAddress
+)  # for hex addresses with checksums
+AnyAddress = TypeVar("AnyAddress", Address, HexAddress, ChecksumAddress)
+HexStr = NewType("HexStr", str)
 Primitives = Union[bytes, int, bool]
-T = TypeVar('T')
+T = TypeVar("T")

--- a/eth_utils/units.py
+++ b/eth_utils/units.py
@@ -1,0 +1,29 @@
+import decimal
+
+# Units are in their own module here, so that they can keep this
+# formatting, as this module is excluded from black in pyproject.toml
+units = {
+    'wei':          decimal.Decimal('1'),  # noqa: E241
+    'kwei':         decimal.Decimal('1000'),  # noqa: E241
+    'babbage':      decimal.Decimal('1000'),  # noqa: E241
+    'femtoether':   decimal.Decimal('1000'),  # noqa: E241
+    'mwei':         decimal.Decimal('1000000'),  # noqa: E241
+    'lovelace':     decimal.Decimal('1000000'),  # noqa: E241
+    'picoether':    decimal.Decimal('1000000'),  # noqa: E241
+    'gwei':         decimal.Decimal('1000000000'),  # noqa: E241
+    'shannon':      decimal.Decimal('1000000000'),  # noqa: E241
+    'nanoether':    decimal.Decimal('1000000000'),  # noqa: E241
+    'nano':         decimal.Decimal('1000000000'),  # noqa: E241
+    'szabo':        decimal.Decimal('1000000000000'),  # noqa: E241
+    'microether':   decimal.Decimal('1000000000000'),  # noqa: E241
+    'micro':        decimal.Decimal('1000000000000'),  # noqa: E241
+    'finney':       decimal.Decimal('1000000000000000'),  # noqa: E241
+    'milliether':   decimal.Decimal('1000000000000000'),  # noqa: E241
+    'milli':        decimal.Decimal('1000000000000000'),  # noqa: E241
+    'ether':        decimal.Decimal('1000000000000000000'),  # noqa: E241
+    'kether':       decimal.Decimal('1000000000000000000000'),  # noqa: E241
+    'grand':        decimal.Decimal('1000000000000000000000'),  # noqa: E241
+    'mether':       decimal.Decimal('1000000000000000000000000'),  # noqa: E241
+    'gether':       decimal.Decimal('1000000000000000000000000000'),  # noqa: E241
+    'tether':       decimal.Decimal('1000000000000000000000000000000'),  # noqa: E241
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+# Exclude eth_utils.units from black 
+[tool.black]
+exclude = 'eth_utils/units.py'

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import (
 
 extras_require = {
     'lint': [
+        'black>=18.6b4,<19',
         'flake8>=3.5.0,<4.0.0',
         "mypy<0.600",
     ],

--- a/tests/abi-utils/test_abi_utils.py
+++ b/tests/abi-utils/test_abi_utils.py
@@ -1,8 +1,6 @@
 import pytest
 
-from eth_utils.hexadecimal import (
-    encode_hex,
-)
+from eth_utils.hexadecimal import encode_hex
 from eth_utils.abi import (
     function_signature_to_4byte_selector,
     function_abi_to_4byte_selector,
@@ -11,34 +9,22 @@ from eth_utils.abi import (
 )
 
 
-FN_ABI_A = {
-    'name': 'tokenLaunched',
-    'type': 'function',
-    'inputs': [],
-}
-FN_ABI_B = {
-    'name': 'CEILING',
-    'type': 'function',
-    'inputs': [],
-}
+FN_ABI_A = {"name": "tokenLaunched", "type": "function", "inputs": []}
+FN_ABI_B = {"name": "CEILING", "type": "function", "inputs": []}
 FN_ABI_C = {
-    'name': 'Registrar',
-    'type': 'function',
-    'inputs': [
-        {'type': 'address', 'name': 'a'},
-        {'type': 'bytes32', 'name': 'b'},
-        {'type': 'address', 'name': 'c'},
+    "name": "Registrar",
+    "type": "function",
+    "inputs": [
+        {"type": "address", "name": "a"},
+        {"type": "bytes32", "name": "b"},
+        {"type": "address", "name": "c"},
     ],
 }
 
 
 @pytest.mark.parametrize(
-    'fn_abi,expected',
-    (
-        (FN_ABI_A, '0xde78e78a'),
-        (FN_ABI_B, '0xc51bf934'),
-        (FN_ABI_C, '0xa31d5580'),
-    ),
+    "fn_abi,expected",
+    ((FN_ABI_A, "0xde78e78a"), (FN_ABI_B, "0xc51bf934"), (FN_ABI_C, "0xa31d5580")),
 )
 def test_fn_abi_to_4byte_selector(fn_abi, expected):
     bytes_selector = function_abi_to_4byte_selector(fn_abi)
@@ -47,11 +33,11 @@ def test_fn_abi_to_4byte_selector(fn_abi, expected):
 
 
 @pytest.mark.parametrize(
-    'signature,expected',
+    "signature,expected",
     (
-        ('tokenLaunched()', '0xde78e78a'),
-        ('CEILING()', '0xc51bf934'),
-        ('Registrar(address,bytes32,address)', '0xa31d5580'),
+        ("tokenLaunched()", "0xde78e78a"),
+        ("CEILING()", "0xc51bf934"),
+        ("Registrar(address,bytes32,address)", "0xa31d5580"),
     ),
 )
 def test_fn_signature_to_4byte_selector(signature, expected):
@@ -73,9 +59,12 @@ EVENT_ABI_A = {
 
 
 @pytest.mark.parametrize(
-    'event_abi,expected',
+    "event_abi,expected",
     (
-        (EVENT_ABI_A, '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'),
+        (
+            EVENT_ABI_A,
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        ),
     ),
 )
 def test_event_abi_to_log_topic(event_abi, expected):
@@ -85,11 +74,11 @@ def test_event_abi_to_log_topic(event_abi, expected):
 
 
 @pytest.mark.parametrize(
-    'event_signature,expected',
+    "event_signature,expected",
     (
         (
-            'Transfer(address,address,uint256)',
-            '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+            "Transfer(address,address,uint256)",
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
         ),
     ),
 )

--- a/tests/address-utils/test_address_utils.py
+++ b/tests/address-utils/test_address_utils.py
@@ -21,51 +21,86 @@ from eth_utils.address import (
         # weird values
         (lambda: None, False, False, False),
         ({}, False, False, False),
-        ( 'function', False, False, False),
-        (b'function', False, False, False),
+        ("function", False, False, False),
+        (b"function", False, False, False),
         # null address
-        ( '0x0000000000000000000000000000000000000000', True, True, False),
-        (b'0x0000000000000000000000000000000000000000', False, False, False),
+        ("0x0000000000000000000000000000000000000000", True, True, False),
+        (b"0x0000000000000000000000000000000000000000", False, False, False),
         # normalized
-        ( '0xc6d9d2cd449a754c494264e1809c50e34d64562b', True, True, False),
-        (b'0xc6d9d2cd449a754c494264e1809c50e34d64562b', False, False, False),
+        ("0xc6d9d2cd449a754c494264e1809c50e34d64562b", True, True, False),
+        (b"0xc6d9d2cd449a754c494264e1809c50e34d64562b", False, False, False),
         # normalized - unprefixed
-        ( 'c6d9d2cd449a754c494264e1809c50e34d64562b', True, True, False),
-        (b'c6d9d2cd449a754c494264e1809c50e34d64562b', False, False, False),
+        ("c6d9d2cd449a754c494264e1809c50e34d64562b", True, True, False),
+        (b"c6d9d2cd449a754c494264e1809c50e34d64562b", False, False, False),
         # checksummed - valid
-        ( '0x5B2063246F2191f18F2675ceDB8b28102e957458', True, True, False),
-        (b'0x5B2063246F2191f18F2675ceDB8b28102e957458', False, False, False),
+        ("0x5B2063246F2191f18F2675ceDB8b28102e957458", True, True, False),
+        (b"0x5B2063246F2191f18F2675ceDB8b28102e957458", False, False, False),
         # checksummed - invalid
-        ( '0x5b2063246F2191f18F2675ceDB8b28102e957458', False, True, False),
-        (b'0x5b2063246F2191f18F2675ceDB8b28102e957458', False, False, False),
+        ("0x5b2063246F2191f18F2675ceDB8b28102e957458", False, True, False),
+        (b"0x5b2063246F2191f18F2675ceDB8b28102e957458", False, False, False),
         # too short - unprefixed
-        ( 'c6d9d2cd449a754c494264e1809c50e34d64562', False, False, False),
-        (b'c6d9d2cd449a754c494264e1809c50e34d64562', False, False, False),
+        ("c6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),
+        (b"c6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),
         # too short
-        ( '0xc6d9d2cd449a754c494264e1809c50e34d64562', False, False, False),
-        (b'0xc6d9d2cd449a754c494264e1809c50e34d64562', False, False, False),
+        ("0xc6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),
+        (b"0xc6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),
         # too long
-        ( '0xc6d9d2cd449a754c494264e1809c50e34d64562bc', False, False, False),
-        (b'0xc6d9d2cd449a754c494264e1809c50e34d64562bc', False, False, False),
+        ("0xc6d9d2cd449a754c494264e1809c50e34d64562bc", False, False, False),
+        (b"0xc6d9d2cd449a754c494264e1809c50e34d64562bc", False, False, False),
         # too long - unprefixed
-        ( 'c6d9d2cd449a754c494264e1809c50e34d64562bc', False, False, False),
-        (b'c6d9d2cd449a754c494264e1809c50e34d64562bc', False, False, False),
+        ("c6d9d2cd449a754c494264e1809c50e34d64562bc", False, False, False),
+        (b"c6d9d2cd449a754c494264e1809c50e34d64562bc", False, False, False),
         # is_binary_address
-        ( '\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', False, False, False),
-        (b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', True, False, True),
+        (
+            "\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
+            False,
+            False,
+            False,
+        ),
+        (
+            b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
+            True,
+            False,
+            True,
+        ),
         # null 30 bytes
-        ( '0x0000000000000000000000000000000000000000000000000000000000000000', False, False, False),
-        (b'0x0000000000000000000000000000000000000000000000000000000000000000', False, False, False),
-        (b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', False, False, False),
+        (
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            False,
+            False,
+            False,
+        ),
+        (
+            b"0x0000000000000000000000000000000000000000000000000000000000000000",
+            False,
+            False,
+            False,
+        ),
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            False,
+            False,
+            False,
+        ),
         # too short
-        ( '0xc6d9d2cd449a754c494264e1809c50e34d6456', False, False, False),
-        ( '0xc6d9d2cd449a754c494264e1809c50e34d64562', False, False, False),
-        (b'0xc6d9d2cd449a754c494264e1809c50e34d64562', False, False, False),
+        ("0xc6d9d2cd449a754c494264e1809c50e34d6456", False, False, False),
+        ("0xc6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),
+        (b"0xc6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),
         # hexstr
-        ('66756e6374696f6e', False, False, False),
-        ('307830303030303030303030303030303030303030303030303030303030303030303030303030303030', False, False, False), # null address
-        ('307863366439643263643434396137353463343934323634653138303963353065333464363435363262', False, False, False), # normalized
-    )
+        ("66756e6374696f6e", False, False, False),
+        (
+            "307830303030303030303030303030303030303030303030303030303030303030303030303030303030",
+            False,
+            False,
+            False,
+        ),  # null address
+        (
+            "307863366439643263643434396137353463343934323634653138303963353065333464363435363262",
+            False,
+            False,
+            False,
+        ),  # normalized
+    ),
 )
 def test_is_address(args, is_any, is_hex, is_binary):
     assert is_address(args) == is_any
@@ -76,21 +111,21 @@ def test_is_address(args, is_any, is_hex, is_binary):
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ('0x52908400098527886E0F7030069857D2E4169EE7', True),
-        ('0x8617E340B3D01FA5F11F306F4090FD50E238070D', True),
-        ('0xde709f2102306220921060314715629080e2fb77', True),
-        ('0x27b1fdb04752bbc536007a920d24acb045561c26', True),
-        ('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', True),
-        ('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', True),
-        ('0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB', True),
-        ('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb', True),
-        ('0xd3cda913deb6f67967b99d67acdfa1712c293601', False),
-        ('0xD3CDA913DEB6F67967B99D67ACDFA1712C293601', False),
-        ('0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB', False),
-        ('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', False),
-        (b'0x52908400098527886E0F7030069857D2E4169EE7', False),
-        (b'0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', False),
-    ]
+        ("0x52908400098527886E0F7030069857D2E4169EE7", True),
+        ("0x8617E340B3D01FA5F11F306F4090FD50E238070D", True),
+        ("0xde709f2102306220921060314715629080e2fb77", True),
+        ("0x27b1fdb04752bbc536007a920d24acb045561c26", True),
+        ("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", True),
+        ("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", True),
+        ("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB", True),
+        ("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb", True),
+        ("0xd3cda913deb6f67967b99d67acdfa1712c293601", False),
+        ("0xD3CDA913DEB6F67967B99D67ACDFA1712C293601", False),
+        ("0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB", False),
+        ("0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", False),
+        (b"0x52908400098527886E0F7030069857D2E4169EE7", False),
+        (b"0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", False),
+    ],
 )
 def test_is_checksum_address(value, expected):
     assert is_checksum_address(value) is expected
@@ -99,21 +134,21 @@ def test_is_checksum_address(value, expected):
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', True),
-        ('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', True),
-        ('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', True),
-        ('0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB', True),
-        ('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb', True),
-        ('0x52908400098527886E0F7030069857D2E4169EE7', False),
-        ('0x8617E340B3D01FA5F11F306F4090FD50E238070D', False),
-        ('0xde709f2102306220921060314715629080e2fb77', False),
-        ('0x27b1fdb04752bbc536007a920d24acb045561c26', False),
-        ('0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB', False),
-        ('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', False),
-        (b'0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', False),
-        (b'0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB', False),
-        (b'0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', False),
-    ]
+        ("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", True),
+        ("0xd3CdA913deB6f67967B99D67aCDFa1712C293601", True),
+        ("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", True),
+        ("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB", True),
+        ("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb", True),
+        ("0x52908400098527886E0F7030069857D2E4169EE7", False),
+        ("0x8617E340B3D01FA5F11F306F4090FD50E238070D", False),
+        ("0xde709f2102306220921060314715629080e2fb77", False),
+        ("0x27b1fdb04752bbc536007a920d24acb045561c26", False),
+        ("0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB", False),
+        ("0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", False),
+        (b"0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed", False),
+        (b"0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB", False),
+        (b"0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", False),
+    ],
 )
 def test_is_checksum_formatted_address(value, expected):
     assert is_checksum_formatted_address(value) is expected
@@ -125,19 +160,28 @@ def test_is_checksum_formatted_address(value, expected):
         (lambda: None, False),
         ("function", False),
         ({}, False),
-        (b'0xc6d9d2cd449a754c494264e1809c50e34d64562b', False),
-        (b'c6d9d2cd449a754c494264e1809c50e34d64562b', False),
-        (b'0xd3cda913deb6f67967b99d67acdfa1712c293601', False),
-        ('307863366439643263643434396137353463343934323634653138303963353065333464363435363262', False),
-        ('63366439643263643434396137353463343934323634653138303963353065333464363435363262', False),
-        ('307864336364613931336465623666363739363762393964363761636466613137313263323933363031', False),
-        ('0xc6d9d2cd449a754c494264e1809c50e34d64562b', True),
-        ('c6d9d2cd449a754c494264e1809c50e34d64562b', False),
-        ('0xd3cda913deb6f67967b99d67acdfa1712c293601', True),
-        ('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', False),
-        ('0xD3CDA913DEB6F67967B99D67ACDFA1712C293601', False),
-        ('0xde709f2102306220921060314715629080e2fb77', True),
-    ]
+        (b"0xc6d9d2cd449a754c494264e1809c50e34d64562b", False),
+        (b"c6d9d2cd449a754c494264e1809c50e34d64562b", False),
+        (b"0xd3cda913deb6f67967b99d67acdfa1712c293601", False),
+        (
+            "307863366439643263643434396137353463343934323634653138303963353065333464363435363262",
+            False,
+        ),
+        (
+            "63366439643263643434396137353463343934323634653138303963353065333464363435363262",
+            False,
+        ),
+        (
+            "307864336364613931336465623666363739363762393964363761636466613137313263323933363031",
+            False,
+        ),
+        ("0xc6d9d2cd449a754c494264e1809c50e34d64562b", True),
+        ("c6d9d2cd449a754c494264e1809c50e34d64562b", False),
+        ("0xd3cda913deb6f67967b99d67acdfa1712c293601", True),
+        ("0xd3CdA913deB6f67967B99D67aCDFa1712C293601", False),
+        ("0xD3CDA913DEB6F67967B99D67ACDFA1712C293601", False),
+        ("0xde709f2102306220921060314715629080e2fb77", True),
+    ],
 )
 def test_is_normalized_address(value, expected):
     assert is_normalized_address(value) is expected
@@ -147,18 +191,18 @@ def test_is_normalized_address(value, expected):
     "value,expected",
     (
         (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
         ),
         (
-            '0XC6D9D2CD449A754C494264E1809C50E34D64562B',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+            "0XC6D9D2CD449A754C494264E1809C50E34D64562B",
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
         ),
         (
-            'C6D9D2CD449A754C494264E1809C50E34D64562B',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+            "C6D9D2CD449A754C494264E1809C50E34D64562B",
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
         ),
-    )
+    ),
 )
 def test_to_normalized_address(value, expected):
     assert to_normalized_address(value) == expected
@@ -168,26 +212,26 @@ def test_to_normalized_address(value, expected):
     "value,expected",
     (
         (
-            '0xd3cda913deb6f67967b99d67acdfa1712c293601',
-            '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
+            "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+            "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
         ),
         (
-            '0xD3CDA913DEB6F67967B99D67ACDFA1712C293601',
-            '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
+            "0xD3CDA913DEB6F67967B99D67ACDFA1712C293601",
+            "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
         ),
         (
-            '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
-            '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
+            "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+            "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
         ),
         (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
         ),
         (
-            'c6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+            "c6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
         ),
-    )
+    ),
 )
 def test_to_checksum_address(value, expected):
     assert to_checksum_address(value) == expected
@@ -197,41 +241,41 @@ def test_to_checksum_address(value, expected):
     "address1,address2,expected",
     (
         (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
             True,
         ),
         (
-            'c6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc6d9d2cD449A754c494264e1809c50e34D64562b',
+            "c6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
             True,
         ),
         (
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
-            '0xc305c901078781c232a2a521c2af7980f8385ee9',
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc305c901078781c232a2a521c2af7980f8385ee9",
             False,
         ),
         (
-            'C6D9D2CD449A754C494264E1809C50E34D64562B',
-            '0xc6d9d2cd449a754c494264e1809c50e34d64562b',
+            "C6D9D2CD449A754C494264E1809C50E34D64562B",
+            "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
             True,
         ),
-    )
+    ),
 )
 def test_is_same_address(address1, address2, expected):
     assert is_same_address(address1, address2) == expected
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
         (
-            '0xd3cda913deb6f67967b99d67acdfa1712c293601',
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
+            "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+            b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
         ),
         (
-            '0xD3CDA913DEB6F67967B99D67ACDFA1712C293601',
-            b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01',
+            "0xD3CDA913DEB6F67967B99D67ACDFA1712C293601",
+            b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
         ),
     ),
 )
@@ -240,13 +284,13 @@ def test_to_canonical_address(value, expected):
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
-	('\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01', False),
-	(b'\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x02', True),
-	('0xd3cda913deb6f67967b99d67acdfa1712c293601', False),
-	(b'0xd3cda913deb6f67967b99d67acdfa1712c293601', False),
-    )
+        ("\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01", False),
+        (b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x02", True),
+        ("0xd3cda913deb6f67967b99d67acdfa1712c293601", False),
+        (b"0xd3cda913deb6f67967b99d67acdfa1712c293601", False),
+    ),
 )
 def test_is_canonical_address(value, expected):
     assert is_canonical_address(value) == expected

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -17,7 +17,7 @@ from eth_utils.curried import (
 
 
 def i_put_my_thing_down_flip_it_and_reverse_it(lyric):
-    return ''.join(reversed(lyric))
+    return "".join(reversed(lyric))
 
 
 CONDITION_FORMATTER_PAIRS = (
@@ -28,25 +28,19 @@ CONDITION_FORMATTER_PAIRS = (
 
 def test_format_dict_error():
     with pytest.raises(ValueError) as exc_info:
-        apply_formatters_to_dict(
-            {'myfield': int},
-            {'myfield': 'a'},
-        )
+        apply_formatters_to_dict({"myfield": int}, {"myfield": "a"})
     with pytest.raises(ValueError) as exc_info:
-        eth_utils.apply_formatters_to_dict(
-            {'myfield': int},
-            {'myfield': 'a'},
-        )
-    assert 'myfield' in str(exc_info.value)
+        eth_utils.apply_formatters_to_dict({"myfield": int}, {"myfield": "a"})
+    assert "myfield" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
-    'formatter, value, expected',
+    "formatter, value, expected",
     (
         (
-            {'should_be_int': int, 'should_be_bool': bool},
-            {'should_be_int': 1.2, 'should_be_bool': 3.4, 'pass_through': 5.6},
-            {'should_be_int': 1, 'should_be_bool': True, 'pass_through': 5.6},
+            {"should_be_int": int, "should_be_bool": bool},
+            {"should_be_int": 1.2, "should_be_bool": 3.4, "pass_through": 5.6},
+            {"should_be_int": 1, "should_be_bool": True, "pass_through": 5.6},
         ),
     ),
 )
@@ -58,12 +52,12 @@ def test_apply_formatters_to_dict(formatter, value, expected):
 
 
 @pytest.mark.parametrize(
-    'formatter, value, expected',
+    "formatter, value, expected",
     (
         (
-            {'black': 'orange', 'Internet': 'Ethereum'},
-            {'black': 1.2, 'Internet': 3.4, 'pass_through': 5.6},
-            {'orange': 1.2, 'Ethereum': 3.4, 'pass_through': 5.6},
+            {"black": "orange", "Internet": "Ethereum"},
+            {"black": 1.2, "Internet": 3.4, "pass_through": 5.6},
+            {"orange": 1.2, "Ethereum": 3.4, "pass_through": 5.6},
         ),
     ),
 )
@@ -75,24 +69,12 @@ def test_apply_key_map(formatter, value, expected):
 
 
 @pytest.mark.parametrize(
-    'formatter, value',
+    "formatter, value",
     (
-        (
-            {'a': 'b'},
-            {'b': 3},
-        ),
-        (
-            {'a': 'b'},
-            {'a': 2, 'b': 3},
-        ),
-        (
-            {'a': 'b'},
-            collections.OrderedDict((('a', 2), ('b', 3))),
-        ),
-        (
-            {'a': 'b'},
-            collections.OrderedDict((('b', 3), ('a', 2))),
-        ),
+        ({"a": "b"}, {"b": 3}),
+        ({"a": "b"}, {"a": 2, "b": 3}),
+        ({"a": "b"}, collections.OrderedDict((("a", 2), ("b", 3)))),
+        ({"a": "b"}, collections.OrderedDict((("b", 3), ("a", 2)))),
     ),
 )
 def test_apply_key_map_with_key_conflicts_raises_exception(formatter, value):
@@ -101,11 +83,11 @@ def test_apply_key_map_with_key_conflicts_raises_exception(formatter, value):
 
 
 @pytest.mark.parametrize(
-    'condition, formatter, value, expected',
+    "condition, formatter, value, expected",
     (
         (is_string, bool, 1, 1),
-        (is_string, bool, '1', True),
-        (is_string, bool, '', False),
+        (is_string, bool, "1", True),
+        (is_string, bool, "", False),
     ),
 )
 def test_apply_formatter_if(condition, formatter, value, expected):
@@ -117,9 +99,9 @@ def test_apply_formatter_if(condition, formatter, value, expected):
 
 
 @pytest.mark.parametrize(
-    'condition_formatters, value, expected',
+    "condition_formatters, value, expected",
     (
-        (CONDITION_FORMATTER_PAIRS, 'my thing', 'gniht ym'),
+        (CONDITION_FORMATTER_PAIRS, "my thing", "gniht ym"),
         (CONDITION_FORMATTER_PAIRS, [2, 3], (2, 3)),
         (CONDITION_FORMATTER_PAIRS, 1, ValueError),
     ),
@@ -131,7 +113,9 @@ def test_apply_one_of_formatters(condition_formatters, value, expected):
         with pytest.raises(expected):
             eth_utils.apply_one_of_formatters(condition_formatters, value)
     else:
-        assert eth_utils.apply_one_of_formatters(condition_formatters, value) == expected
+        assert (
+            eth_utils.apply_one_of_formatters(condition_formatters, value) == expected
+        )
 
         # must be able to curry
         apply_one = apply_one_of_formatters(condition_formatters)
@@ -139,7 +123,7 @@ def test_apply_one_of_formatters(condition_formatters, value, expected):
 
 
 @pytest.mark.parametrize(
-    'formatter, index, value, expected',
+    "formatter, index, value, expected",
     (
         (bool, 1, [1, 2, 3], [1, True, 3]),
         (bool, 1, (1, 2, 3), (1, True, 3)),
@@ -161,32 +145,19 @@ def test_apply_formatter_at_index(formatter, index, value, expected):
 
 
 SEQUENCE_FORMATTER_PARAMETERS = (
-    (
-        [bool, int, str],
-        (1.2, 3.4, 5.6),
-        (True, 3, '5.6'),
-    ),
-    (
-        [bool, int, str],
-        [1.2, 3.4, 5.6],
-        [True, 3, '5.6'],
-    ),
-    (
-        [bool, int, str, float],
-        (1.2, 3.4, 5.6),
-        IndexError,
-    ),
+    ([bool, int, str], (1.2, 3.4, 5.6), (True, 3, "5.6")),
+    ([bool, int, str], [1.2, 3.4, 5.6], [True, 3, "5.6"]),
+    ([bool, int, str, float], (1.2, 3.4, 5.6), IndexError),
 )
 
 LOOSE_SEQUENCE_FORMATTER_PARAMETERS = SEQUENCE_FORMATTER_PARAMETERS + (
-    (
-        [bool, int],
-        (1.2, 3.4, 5.6),
-        (True, 3, 5.6),
-    ),
+    ([bool, int], (1.2, 3.4, 5.6), (True, 3, 5.6)),
 )
 
-@pytest.mark.parametrize('formatters, value, expected', LOOSE_SEQUENCE_FORMATTER_PARAMETERS)
+
+@pytest.mark.parametrize(
+    "formatters, value, expected", LOOSE_SEQUENCE_FORMATTER_PARAMETERS
+)
 def test_combine_argument_formatters(formatters, value, expected):
     list_formatter = eth_utils.combine_argument_formatters(*formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
@@ -195,15 +166,15 @@ def test_combine_argument_formatters(formatters, value, expected):
     else:
         assert list_formatter(value) == expected
 
+
 STRICT_SEQUENCE_FORMATTER_PARAMETERS = SEQUENCE_FORMATTER_PARAMETERS + (
-    (
-        [bool, int],
-        (1.2, 3.4, 5.6),
-        IndexError,
-    ),
+    ([bool, int], (1.2, 3.4, 5.6), IndexError),
 )
 
-@pytest.mark.parametrize('formatters, value, expected', STRICT_SEQUENCE_FORMATTER_PARAMETERS)
+
+@pytest.mark.parametrize(
+    "formatters, value, expected", STRICT_SEQUENCE_FORMATTER_PARAMETERS
+)
 def test_apply_formatters_to_sequence_curried(formatters, value, expected):
     list_formatter = apply_formatters_to_sequence(formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
@@ -213,7 +184,9 @@ def test_apply_formatters_to_sequence_curried(formatters, value, expected):
         assert list_formatter(value) == expected
 
 
-@pytest.mark.parametrize('formatters, value, expected', STRICT_SEQUENCE_FORMATTER_PARAMETERS)
+@pytest.mark.parametrize(
+    "formatters, value, expected", STRICT_SEQUENCE_FORMATTER_PARAMETERS
+)
 def test_apply_formatters_to_sequence(formatters, value, expected):
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
@@ -223,19 +196,8 @@ def test_apply_formatters_to_sequence(formatters, value, expected):
 
 
 @pytest.mark.parametrize(
-    'formatter, value, expected',
-    (
-        (
-            int,
-            [1.2, 3.4, 5.6],
-            [1, 3, 5],
-        ),
-        (
-            int,
-            (1.2, 3.4, 5.6),
-            (1, 3, 5),
-        ),
-    ),
+    "formatter, value, expected",
+    ((int, [1.2, 3.4, 5.6], [1, 3, 5]), (int, (1.2, 3.4, 5.6), (1, 3, 5))),
 )
 def test_apply_formatter_to_array(formatter, value, expected):
     assert eth_utils.apply_formatter_to_array(formatter, value) == expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import warnings
- 
- 
+
+
 @pytest.fixture(autouse=True)
 def print_warnings():
-    warnings.simplefilter('always')
+    warnings.simplefilter("always")

--- a/tests/conversion-utils/test_conversions.py
+++ b/tests/conversion-utils/test_conversions.py
@@ -2,30 +2,25 @@
 
 import pytest
 
-from eth_utils import (
-    to_int,
-    to_bytes,
-    to_hex,
-    to_text,
-)
+from eth_utils import to_int, to_bytes, to_hex, to_text
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        (b'\x01', b'\x01'),
-        (b'\xff', b'\xff'),
-        (b'\x00', b'\x00'),
-        (bytearray(b'\x01'), b'\x01'),
-        (bytearray(b'\xff'), b'\xff'),
-        (bytearray(b'\x00'), b'\x00'),
-        (0x1, b'\x01'),
-        (0x0001, b'\x01'),
-        (0xFF, b'\xff'),
-        (0, b'\x00'),
-        (256, b'\x01\x00'),
-        (True, b'\x01'),
-        (False, b'\x00'),
+        (b"\x01", b"\x01"),
+        (b"\xff", b"\xff"),
+        (b"\x00", b"\x00"),
+        (bytearray(b"\x01"), b"\x01"),
+        (bytearray(b"\xff"), b"\xff"),
+        (bytearray(b"\x00"), b"\x00"),
+        (0x1, b"\x01"),
+        (0x0001, b"\x01"),
+        (0xFF, b"\xff"),
+        (0, b"\x00"),
+        (256, b"\x01\x00"),
+        (True, b"\x01"),
+        (False, b"\x00"),
     ),
 )
 def test_to_bytes_primitive(val, expected):
@@ -33,49 +28,43 @@ def test_to_bytes_primitive(val, expected):
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        ('0x', b''),
-        ('0x0', b'\x00'),
-        ('0x1', b'\x01'),
-        ('0', b'\x00'),
-        ('1', b'\x01'),
-        ('0xFF', b'\xff'),
-        ('0x100', b'\x01\x00'),
-        ('0x0000', b'\x00\x00'),
-        ('0000', b'\x00\x00'),
+        ("0x", b""),
+        ("0x0", b"\x00"),
+        ("0x1", b"\x01"),
+        ("0", b"\x00"),
+        ("1", b"\x01"),
+        ("0xFF", b"\xff"),
+        ("0x100", b"\x01\x00"),
+        ("0x0000", b"\x00\x00"),
+        ("0000", b"\x00\x00"),
     ),
 )
 def test_to_bytes_hexstr(val, expected):
     assert to_bytes(hexstr=val) == expected
 
 
-@pytest.mark.parametrize(
-    'val, expected',
-    (
-        ('cowmö', b'cowm\xc3\xb6'),
-        ('', b''),
-    ),
-)
+@pytest.mark.parametrize("val, expected", (("cowmö", b"cowm\xc3\xb6"), ("", b"")))
 def test_to_bytes_text(val, expected):
     assert to_bytes(text=val) == expected
 
 
 def test_to_text_identity():
-    assert to_text(text='pass-through') == 'pass-through'
+    assert to_text(text="pass-through") == "pass-through"
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        (b'', ''),
-        (bytearray(b''), ''),
-        ('0x', ''),
-        (b'cowm\xc3\xb6', 'cowmö'),
-        (bytearray(b'cowm\xc3\xb6'), 'cowmö'),
-        ('0x636f776dc3b6', 'cowmö'),
-        (0x636f776dc3b6, 'cowmö'),
-        ('0xa', '\n'),
+        (b"", ""),
+        (bytearray(b""), ""),
+        ("0x", ""),
+        (b"cowm\xc3\xb6", "cowmö"),
+        (bytearray(b"cowm\xc3\xb6"), "cowmö"),
+        ("0x636f776dc3b6", "cowmö"),
+        (0x636f776dc3b6, "cowmö"),
+        ("0xa", "\n"),
     ),
 )
 def test_to_text(val, expected):
@@ -83,35 +72,30 @@ def test_to_text(val, expected):
 
 
 @pytest.mark.parametrize(
-    'val, expected',
-    (
-        ('0x', ''),
-        ('0xa', '\n'),
-        ('0x636f776dc3b6', 'cowmö'),
-        ('636f776dc3b6', 'cowmö'),
-    ),
+    "val, expected",
+    (("0x", ""), ("0xa", "\n"), ("0x636f776dc3b6", "cowmö"), ("636f776dc3b6", "cowmö")),
 )
 def test_to_text_hexstr(val, expected):
     assert to_text(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        (b'\x00', 0),
-        (b'\x01', 1),
-        (b'\x00\x01', 1),
-        (b'\x01\x00', 256),
-        (bytearray(b'\x00'), 0),
-        (bytearray(b'\x01'), 1),
-        (bytearray(b'\x00\x01'), 1),
-        (bytearray(b'\x01\x00'), 256),
+        (b"\x00", 0),
+        (b"\x01", 1),
+        (b"\x00\x01", 1),
+        (b"\x01\x00", 256),
+        (bytearray(b"\x00"), 0),
+        (bytearray(b"\x01"), 1),
+        (bytearray(b"\x00\x01"), 1),
+        (bytearray(b"\x01\x00"), 256),
         (True, 1),
         (False, 0),
-        ('255', TypeError),
-        ('-1', TypeError),
-        ('0x0', TypeError),
-        ('0x1', TypeError),
+        ("255", TypeError),
+        ("-1", TypeError),
+        ("0x0", TypeError),
+        ("0x1", TypeError),
     ),
 )
 def test_to_int(val, expected):
@@ -123,15 +107,15 @@ def test_to_int(val, expected):
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        ('0', 0),
-        ('-1', -1),
-        ('255', 255),
-        ('0x0', ValueError),
-        ('0x1', ValueError),
-        ('1.1', ValueError),
-        ('a', ValueError),
+        ("0", 0),
+        ("-1", -1),
+        ("255", 255),
+        ("0x0", ValueError),
+        ("0x1", ValueError),
+        ("1.1", ValueError),
+        ("a", ValueError),
     ),
 )
 def test_to_int_text(val, expected):
@@ -143,16 +127,16 @@ def test_to_int_text(val, expected):
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        ('0x0', 0),
-        ('0x1', 1),
-        ('0x01', 1),
-        ('0x10', 16),
-        ('0', 0),
-        ('1', 1),
-        ('01', 1),
-        ('10', 16),
+        ("0x0", 0),
+        ("0x1", 1),
+        ("0x01", 1),
+        ("0x10", 16),
+        ("0", 0),
+        ("1", 1),
+        ("01", 1),
+        ("10", 16),
     ),
 )
 def test_to_int_hexstr(val, expected):
@@ -160,54 +144,48 @@ def test_to_int_hexstr(val, expected):
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        (b'\x00', '0x00'),
-        (b'\x01', '0x01'),
-        (b'\x10', '0x10'),
-        (b'\x01\x00', '0x0100'),
-        (b'\x00\x0F', '0x000f'),
-        (b'', '0x'),
-        (bytearray(b'\x00'), '0x00'),
-        (bytearray(b'\x01'), '0x01'),
-        (bytearray(b'\x10'), '0x10'),
-        (bytearray(b'\x01\x00'), '0x0100'),
-        (bytearray(b'\x00\x0F'), '0x000f'),
-        (bytearray(b''), '0x'),
-        (0, '0x0'),
-        (1, '0x1'),
-        (16, '0x10'),
-        (256, '0x100'),
-        (0x0, '0x0'),
-        (0x0F, '0xf'),
-        (False, '0x0'),
-        (True, '0x1'),
+        (b"\x00", "0x00"),
+        (b"\x01", "0x01"),
+        (b"\x10", "0x10"),
+        (b"\x01\x00", "0x0100"),
+        (b"\x00\x0F", "0x000f"),
+        (b"", "0x"),
+        (bytearray(b"\x00"), "0x00"),
+        (bytearray(b"\x01"), "0x01"),
+        (bytearray(b"\x10"), "0x10"),
+        (bytearray(b"\x01\x00"), "0x0100"),
+        (bytearray(b"\x00\x0F"), "0x000f"),
+        (bytearray(b""), "0x"),
+        (0, "0x0"),
+        (1, "0x1"),
+        (16, "0x10"),
+        (256, "0x100"),
+        (0x0, "0x0"),
+        (0x0F, "0xf"),
+        (False, "0x0"),
+        (True, "0x1"),
     ),
 )
 def test_to_hex(val, expected):
     assert to_hex(val) == expected
 
 
-@pytest.mark.parametrize(
-    'val, expected',
-    (
-        ('', '0x'),
-        ('cowmö', '0x636f776dc3b6'),
-    ),
-)
+@pytest.mark.parametrize("val, expected", (("", "0x"), ("cowmö", "0x636f776dc3b6")))
 def test_to_hex_text(val, expected):
     assert to_hex(text=val) == expected
 
 
 @pytest.mark.parametrize(
-    'val, expected',
+    "val, expected",
     (
-        ('0x0', '0x0'),
-        ('0x1', '0x1'),
-        ('0x0001', '0x0001'),
-        ('0x10', '0x10'),
-        ('0xF', '0xf'),
-        ('F', '0xf'),
+        ("0x0", "0x0"),
+        ("0x1", "0x1"),
+        ("0x0001", "0x0001"),
+        ("0x10", "0x10"),
+        ("0xF", "0xf"),
+        ("F", "0xf"),
     ),
 )
 def test_to_hex_cleanup_only(val, expected):
@@ -216,4 +194,4 @@ def test_to_hex_cleanup_only(val, expected):
 
 def test_to_hex_exception():
     with pytest.raises(TypeError, match="Unsupported type: The primitive argument"):
-        to_hex(primitive='string')
+        to_hex(primitive="string")

--- a/tests/currency-utils/test_currency_tools.py
+++ b/tests/currency-utils/test_currency_tools.py
@@ -1,18 +1,9 @@
 import decimal
 
 import pytest
-from hypothesis import (
-    given,
-    strategies as st,
-)
+from hypothesis import given, strategies as st
 
-from eth_utils.currency import (
-    units,
-    to_wei,
-    from_wei,
-    MIN_WEI,
-    MAX_WEI,
-)
+from eth_utils.currency import units, to_wei, from_wei, MIN_WEI, MAX_WEI
 
 
 @given(
@@ -32,41 +23,38 @@ MAX_ETHER_DECIMAL = 999999999999999999
 
 def make_ether_string_value(amount_in_wei):
     s_amount_in_wei = str(amount_in_wei)
-    whole_part = s_amount_in_wei[:-18] or '0'
+    whole_part = s_amount_in_wei[:-18] or "0"
     decimal_part = s_amount_in_wei[-18:]
 
     s_amount_in_ether = "{0}.{1}".format(
-        whole_part,
-        decimal_part.zfill(18).rstrip('0'),
-    ).rstrip('.')
+        whole_part, decimal_part.zfill(18).rstrip("0")
+    ).rstrip(".")
     return s_amount_in_ether
 
 
-@given(
-    st.integers(min_value=0, max_value=MAX_WEI).map(make_ether_string_value)
-)
+@given(st.integers(min_value=0, max_value=MAX_WEI).map(make_ether_string_value))
 def test_conversion_revers_round_trip_trip(amount_in_ether):
-    intermediate_amount = to_wei(amount_in_ether, 'ether')
-    result_amount = from_wei(intermediate_amount, 'ether')
+    intermediate_amount = to_wei(amount_in_ether, "ether")
+    result_amount = from_wei(intermediate_amount, "ether")
     assert decimal.Decimal(result_amount) == decimal.Decimal(str(amount_in_ether))
 
 
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ([1000000000000000000, 'wei'], '1000000000000000000'),
-        ([1000000000000000000, 'kwei'], '1000000000000000'),
-        ([1000000000000000000, 'mwei'], '1000000000000'),
-        ([1000000000000000000, 'gwei'], '1000000000'),
-        ([1000000000000000000, 'szabo'], '1000000'),
-        ([1000000000000000000, 'finney'], '1000'),
-        ([1000000000000000000, 'ether'], '1'),
-        ([1000000000000000000, 'kether'], '0.001'),
-        ([1000000000000000000, 'grand'], '0.001'),
-        ([1000000000000000000, 'mether'], '0.000001'),
-        ([1000000000000000000, 'gether'], '0.000000001'),
-        ([1000000000000000000, 'tether'], '0.000000000001'),
-    ]
+        ([1000000000000000000, "wei"], "1000000000000000000"),
+        ([1000000000000000000, "kwei"], "1000000000000000"),
+        ([1000000000000000000, "mwei"], "1000000000000"),
+        ([1000000000000000000, "gwei"], "1000000000"),
+        ([1000000000000000000, "szabo"], "1000000"),
+        ([1000000000000000000, "finney"], "1000"),
+        ([1000000000000000000, "ether"], "1"),
+        ([1000000000000000000, "kether"], "0.001"),
+        ([1000000000000000000, "grand"], "0.001"),
+        ([1000000000000000000, "mether"], "0.000001"),
+        ([1000000000000000000, "gether"], "0.000000001"),
+        ([1000000000000000000, "tether"], "0.000000000001"),
+    ],
 )
 def test_from_wei(value, expected):
     assert from_wei(*value) == decimal.Decimal(expected)
@@ -75,40 +63,33 @@ def test_from_wei(value, expected):
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ([1, 'wei'], '1'),
-        ([1, 'kwei'], '1000'),
-        ([1, 'Kwei'], '1000'),
-        ([1, 'babbage'], '1000'),
-        ([1, 'mwei'], '1000000'),
-        ([1, 'Mwei'], '1000000'),
-        ([1, 'lovelace'], '1000000'),
-        ([1, 'gwei'], '1000000000'),
-        ([1, 'Gwei'], '1000000000'),
-        ([1, 'shannon'], '1000000000'),
-        ([1, 'szabo'], '1000000000000'),
-        ([1, 'finney'], '1000000000000000'),
-        ([1, 'ether'], '1000000000000000000'),
-        ([1, 'kether'], '1000000000000000000000'),
-        ([1, 'grand'], '1000000000000000000000'),
-        ([1, 'mether'], '1000000000000000000000000'),
-        ([1, 'gether'], '1000000000000000000000000000'),
-        ([1, 'tether'], '1000000000000000000000000000000'),
-        ([0.05, 'ether'], '50000000000000000'),
-        ([1.2, 'ether'], '1200000000000000000'),
-    ]
+        ([1, "wei"], "1"),
+        ([1, "kwei"], "1000"),
+        ([1, "Kwei"], "1000"),
+        ([1, "babbage"], "1000"),
+        ([1, "mwei"], "1000000"),
+        ([1, "Mwei"], "1000000"),
+        ([1, "lovelace"], "1000000"),
+        ([1, "gwei"], "1000000000"),
+        ([1, "Gwei"], "1000000000"),
+        ([1, "shannon"], "1000000000"),
+        ([1, "szabo"], "1000000000000"),
+        ([1, "finney"], "1000000000000000"),
+        ([1, "ether"], "1000000000000000000"),
+        ([1, "kether"], "1000000000000000000000"),
+        ([1, "grand"], "1000000000000000000000"),
+        ([1, "mether"], "1000000000000000000000000"),
+        ([1, "gether"], "1000000000000000000000000000"),
+        ([1, "tether"], "1000000000000000000000000000000"),
+        ([0.05, "ether"], "50000000000000000"),
+        ([1.2, "ether"], "1200000000000000000"),
+    ],
 )
 def test_to_wei(value, expected):
     assert to_wei(*value) == decimal.Decimal(expected)
 
 
-@pytest.mark.parametrize(
-    'value,unit',
-    (
-        (1, 'wei1'),
-        (1, 'not-a-unit'),
-        (-1, 'ether'),
-    )
-)
+@pytest.mark.parametrize("value,unit", ((1, "wei1"), (1, "not-a-unit"), (-1, "ether")))
 def test_invalid_to_wei_values(value, unit):
     with pytest.raises(ValueError):
         to_wei(value, unit)

--- a/tests/curried-utils/test_curried.py
+++ b/tests/curried-utils/test_curried.py
@@ -1,27 +1,9 @@
 try:
-    from cytoolz import (
-        curry,
-        keyfilter,
-        merge_with,
-        valfilter,
-    )
-    from cytoolz.functoolz import (
-        Compose,
-        has_keywords,
-        num_required_args,
-    )
+    from cytoolz import curry, keyfilter, merge_with, valfilter
+    from cytoolz.functoolz import Compose, has_keywords, num_required_args
 except ImportError:
-    from toolz import (
-        curry,
-        keyfilter,
-        merge_with,
-        valfilter,
-    )
-    from toolz.functoolz import (
-        Compose,
-        has_keywords,
-        num_required_args,
-    )
+    from toolz import curry, keyfilter, merge_with, valfilter
+    from toolz.functoolz import Compose, has_keywords, num_required_args
 
 import eth_utils
 import eth_utils.curried
@@ -56,12 +38,9 @@ def test_curried_namespace():
 
     def curry_namespace(ns):
         return dict(
-            (
-                name,
-                curry(f) if should_curry(f) else f,
-            )
+            (name, curry(f) if should_curry(f) else f)
             for name, f in ns.items()
-            if '__' not in name
+            if "__" not in name
         )
 
     all_auto_curried = curry_namespace(vars(eth_utils))
@@ -74,32 +53,32 @@ def test_curried_namespace():
         if missing:
             to_insert = sorted("%s," % f for f in missing)
             raise AssertionError(
-                'There are missing functions in eth_utils.curried:\n' +
-                '\n'.join(to_insert)
+                "There are missing functions in eth_utils.curried:\n"
+                + "\n".join(to_insert)
             )
         extra = set(curried_namespace) - set(inferred_namespace)
         if extra:
             raise AssertionError(
-                'There are extra functions in eth_utils.curried:\n' +
-                '\n'.join(sorted(extra))
+                "There are extra functions in eth_utils.curried:\n"
+                + "\n".join(sorted(extra))
             )
         unequal = merge_with(list, inferred_namespace, curried_namespace)
         unequal = valfilter(lambda x: x[0] != x[1], unequal)
         to_curry = keyfilter(lambda x: should_curry(getattr(eth_utils, x)), unequal)
         if to_curry:
-            to_curry_formatted = sorted('{0} = curry({0})'.format(f) for f in to_curry)
+            to_curry_formatted = sorted("{0} = curry({0})".format(f) for f in to_curry)
             raise AssertionError(
-                'There are missing functions to curry in eth_utils.curried:\n' +
-                '\n'.join(to_curry_formatted)
+                "There are missing functions to curry in eth_utils.curried:\n"
+                + "\n".join(to_curry_formatted)
             )
         elif unequal:
             not_to_curry_formatted = sorted(unequal)
             raise AssertionError(
-                'Missing functions NOT to curry in eth_utils.curried:\n' +
-                '\n'.join(not_to_curry_formatted)
+                "Missing functions NOT to curry in eth_utils.curried:\n"
+                + "\n".join(not_to_curry_formatted)
             )
         else:
-            raise AssertionError("unexplained difference between %r and %r" % (
-                inferred_namespace,
-                curried_namespace,
-            ))
+            raise AssertionError(
+                "unexplained difference between %r and %r"
+                % (inferred_namespace, curried_namespace)
+            )

--- a/tests/decorator-utils/test_combomethod.py
+++ b/tests/decorator-utils/test_combomethod.py
@@ -1,8 +1,6 @@
 import pytest
 
-from eth_utils import (
-    combomethod,
-)
+from eth_utils import combomethod
 
 
 @pytest.fixture()
@@ -18,14 +16,15 @@ def Getter():
                 return "%d by instance" % combo.val
             else:
                 raise TypeError("Unreachable, unless you really monkey around")
+
     return _Getter
 
 
 def test_class_access(Getter):
-    assert Getter.get() == '1 by class'
+    assert Getter.get() == "1 by class"
 
 
 def test_instance_access(Getter):
     getter = Getter()
     getter.val = 2
-    assert getter.get() == '2 by instance'
+    assert getter.get() == "2 by instance"

--- a/tests/decorator-utils/test_replace_exceptions.py
+++ b/tests/decorator-utils/test_replace_exceptions.py
@@ -8,16 +8,17 @@ def mock_function_with_exception(old_to_new):
     @replace_exceptions(old_to_new)
     def function_with_exception(x):
         raise TypeError
+
     return function_with_exception
 
 
 @pytest.mark.parametrize(
-    'old_to_new,new',
+    "old_to_new,new",
     (
         ({TypeError: AttributeError}, AttributeError),
         ({TypeError: NameError}, NameError),
         ({ValueError: AttributeError, TypeError: NameError}, NameError),
-    )
+    ),
 )
 def test_decorator_replaces_exceptions(mock_function_with_exception, old_to_new, new):
     with pytest.raises(new):

--- a/tests/decorator-utils/test_validate_conversion_arguments.py
+++ b/tests/decorator-utils/test_validate_conversion_arguments.py
@@ -1,8 +1,6 @@
 import pytest
 
-from eth_utils.decorators import (
-    validate_conversion_arguments,
-)
+from eth_utils.decorators import validate_conversion_arguments
 
 
 @pytest.fixture()
@@ -10,44 +8,33 @@ def mock_conversion_function():
     @validate_conversion_arguments
     def conversion_function(primitive=None, hexstr=None, text=None):
         return True
+
     return conversion_function
 
 
-@pytest.mark.parametrize(
-    'val',
-    (
-        b'123',
-        123,
-        {},
-        lambda: None,
-    )
-)
-def test_decorator_rejects_non_text_type_args_for_hexstr_kwarg(mock_conversion_function, val):
+@pytest.mark.parametrize("val", (b"123", 123, {}, lambda: None))
+def test_decorator_rejects_non_text_type_args_for_hexstr_kwarg(
+    mock_conversion_function, val
+):
     with pytest.raises(TypeError):
         mock_conversion_function(hexstr=val)
 
 
-@pytest.mark.parametrize(
-    'val',
-    (
-        b'123',
-        123,
-        {},
-        lambda: None,
-    )
-)
-def test_decorator_rejects_non_text_type_args_for_text_kwarg(mock_conversion_function, val):
+@pytest.mark.parametrize("val", (b"123", 123, {}, lambda: None))
+def test_decorator_rejects_non_text_type_args_for_text_kwarg(
+    mock_conversion_function, val
+):
     with pytest.raises(TypeError):
         mock_conversion_function(text=val)
 
 
 @pytest.mark.parametrize(
-    'values',
+    "values",
     (
         {},
-        {'primitive': 'abc', 'hexstr': 'abc'},
-        {'primitive': 'abc', 'hexstr': 'abc', 'text': 'abc'},
-    )
+        {"primitive": "abc", "hexstr": "abc"},
+        {"primitive": "abc", "hexstr": "abc", "text": "abc"},
+    ),
 )
 def test_decorator_only_accepts_a_single_arg(mock_conversion_function, values):
     with pytest.raises(TypeError):
@@ -56,16 +43,11 @@ def test_decorator_only_accepts_a_single_arg(mock_conversion_function, values):
 
 def test_decorator_rejects_invalid_kwarg(mock_conversion_function):
     with pytest.raises(TypeError):
-        mock_conversion_function(value='123')
+        mock_conversion_function(value="123")
 
 
 @pytest.mark.parametrize(
-    'values',
-    (
-        {'primitive': 'abc'},
-        {'hexstr': 'abc'},
-        {'text': 'abc'},
-    )
+    "values", ({"primitive": "abc"}, {"hexstr": "abc"}, {"text": "abc"})
 )
 def test_decorator_accepts_a_single_text_arg(mock_conversion_function, values):
     actual = mock_conversion_function(**values)

--- a/tests/encoding-utils/test_big_endian_integer.py
+++ b/tests/encoding-utils/test_big_endian_integer.py
@@ -1,26 +1,20 @@
 import pytest
 
-from hypothesis import (
-    strategies as st,
-    given,
-)
+from hypothesis import strategies as st, given
 
-from eth_utils.encoding import (
-    int_to_big_endian,
-    big_endian_to_int,
-)
+from eth_utils.encoding import int_to_big_endian, big_endian_to_int
 
 
 @pytest.mark.parametrize(
-    'as_int,as_big_endian',
+    "as_int,as_big_endian",
     (
-        (0, b'\x00'),
-        (1, b'\x01'),
-        (7, b'\x07'),
-        (8, b'\x08'),
-        (9, b'\x09'),
-        (256, b'\x01\x00'),
-        (2**256 - 1, b'\xff' * 32),
+        (0, b"\x00"),
+        (1, b"\x01"),
+        (7, b"\x07"),
+        (8, b"\x08"),
+        (9, b"\x09"),
+        (256, b"\x01\x00"),
+        (2 ** 256 - 1, b"\xff" * 32),
     ),
 )
 def test_big_endian_conversions(as_int, as_big_endian):
@@ -31,16 +25,14 @@ def test_big_endian_conversions(as_int, as_big_endian):
     assert as_big_endian_result == as_big_endian
 
 
-@given(value=st.integers(min_value=0, max_value=2**256 - 1))
+@given(value=st.integers(min_value=0, max_value=2 ** 256 - 1))
 def test_big_endian_round_trip_from_int(value):
     result = big_endian_to_int(int_to_big_endian(value))
     assert result == value
 
 
 @given(
-    value=st.binary(min_size=1, max_size=32).map(
-        lambda v: v.lstrip(b'\x00') or b'\x00'
-    )
+    value=st.binary(min_size=1, max_size=32).map(lambda v: v.lstrip(b"\x00") or b"\x00")
 )
 def test_big_endian_round_trip_from_big_endian(value):
     result = int_to_big_endian(big_endian_to_int(value))

--- a/tests/functional-utils/test_return_value_decorators.py
+++ b/tests/functional-utils/test_return_value_decorators.py
@@ -31,21 +31,21 @@ def test_to_list():
 
 def test_to_dict():
     fn = to_dict(yield_things)
-    actual = fn(('a', 1), ('b', 2), ('c', 3))
-    assert actual == {'a': 1, 'b': 2, 'c': 3}
+    actual = fn(("a", 1), ("b", 2), ("c", 3))
+    assert actual == {"a": 1, "b": 2, "c": 3}
 
 
 def test_to_ordered_dict():
     fn = to_ordered_dict(yield_things)
-    actual = fn(('b', 2), ('d', 4), ('a', 1), ('c', 3))
-    assert actual == collections.OrderedDict((('b', 2), ('d', 4), ('a', 1), ('c', 3)))
-    assert tuple(actual.items()) == (('b', 2), ('d', 4), ('a', 1), ('c', 3))
+    actual = fn(("b", 2), ("d", 4), ("a", 1), ("c", 3))
+    assert actual == collections.OrderedDict((("b", 2), ("d", 4), ("a", 1), ("c", 3)))
+    assert tuple(actual.items()) == (("b", 2), ("d", 4), ("a", 1), ("c", 3))
 
 
 def test_to_set():
     fn = to_set(yield_things)
-    actual = fn('a', 'b', 'a', 'c')
-    assert actual == {'a', 'b', 'c'}
+    actual = fn("a", "b", "a", "c")
+    assert actual == {"a", "b", "c"}
 
 
 def test_sorted_return():

--- a/tests/hexadecimal-utils/test_0x_prefix_addition_and_removal.py
+++ b/tests/hexadecimal-utils/test_0x_prefix_addition_and_removal.py
@@ -1,19 +1,16 @@
 import pytest
 
-from eth_utils.hexadecimal import (
-    add_0x_prefix,
-    remove_0x_prefix,
-)
+from eth_utils.hexadecimal import add_0x_prefix, remove_0x_prefix
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
-        ('', '0x'),
-        ('0x', '0x'),
-        ('0x12345', '0x12345'),
-        ('0X12345', '0X12345'),
-        ('12345', '0x12345'),
+        ("", "0x"),
+        ("0x", "0x"),
+        ("0x12345", "0x12345"),
+        ("0X12345", "0X12345"),
+        ("12345", "0x12345"),
     ),
 )
 def test_add_0x_prefix(value, expected):
@@ -21,20 +18,20 @@ def test_add_0x_prefix(value, expected):
     assert actual == expected
 
 
-@pytest.mark.parametrize('value', (b'', 123, {}, lambda: None))
+@pytest.mark.parametrize("value", (b"", 123, {}, lambda: None))
 def test_add_0x_prefix_rejects_non_text_types(value):
     with pytest.raises(TypeError):
         add_0x_prefix(value)
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
-        ('', ''),
-        ('0x', ''),
-        ('0x12345', '12345'),
-        ('0X12345', '12345'),
-        ('12345', '12345'),
+        ("", ""),
+        ("0x", ""),
+        ("0x12345", "12345"),
+        ("0X12345", "12345"),
+        ("12345", "12345"),
     ),
 )
 def test_remove_0x_prefix(value, expected):
@@ -42,7 +39,7 @@ def test_remove_0x_prefix(value, expected):
     assert actual == expected
 
 
-@pytest.mark.parametrize('value', (b'', 123, {}, lambda: None))
+@pytest.mark.parametrize("value", (b"", 123, {}, lambda: None))
 def test_remove_0x_prefix_rejects_non_text_types(value):
     with pytest.raises(TypeError):
         remove_0x_prefix(value)

--- a/tests/hexadecimal-utils/test_is_0x_prefixed.py
+++ b/tests/hexadecimal-utils/test_is_0x_prefixed.py
@@ -1,25 +1,17 @@
 import pytest
 
-from eth_utils.hexadecimal import (
-    is_0x_prefixed,
-)
+from eth_utils.hexadecimal import is_0x_prefixed
 
 
 @pytest.mark.parametrize(
-    'value,expected',
-    (
-        ('', False),
-        ('0x', True),
-        ('0x12345', True),
-        ('12345', False),
-        ('0X12345', True),
-    ),
+    "value,expected",
+    (("", False), ("0x", True), ("0x12345", True), ("12345", False), ("0X12345", True)),
 )
 def test_is_0x_prefixed(value, expected):
     assert is_0x_prefixed(value) is expected
 
 
-@pytest.mark.parametrize('value', (b'', 123, {}, lambda: None))
+@pytest.mark.parametrize("value", (b"", 123, {}, lambda: None))
 def test_is_0x_prefixed_rejects_non_text_types(value):
     with pytest.raises(TypeError):
         is_0x_prefixed(value)

--- a/tests/hexadecimal-utils/test_is_hex.py
+++ b/tests/hexadecimal-utils/test_is_hex.py
@@ -1,27 +1,25 @@
 import pytest
 
-from eth_utils import (
-    is_hex,
-)
+from eth_utils import is_hex
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
-        ('', False),  # empty string
-        ('0x', True),  # empty string
-        ('0X', True),  # empty string
-        ('abcdef1234567890', True),
-        ('ABCDEF1234567890', True),
-        ('AbCdEf1234567890', True),
-        ('0xabcdef1234567890', True),
-        ('0xABCDEF1234567890', True),
-        ('0xAbCdEf1234567890', True),
-        ('12345', True),  # odd length
-        ('0x12345', True),  # odd length
-        ('123456xx', False),  # non-hex character
-        ('0x123456xx', False),  # non-hex character
-        ('0\u0080', False),  # triggers different exceptions in py2 and py3
+        ("", False),  # empty string
+        ("0x", True),  # empty string
+        ("0X", True),  # empty string
+        ("abcdef1234567890", True),
+        ("ABCDEF1234567890", True),
+        ("AbCdEf1234567890", True),
+        ("0xabcdef1234567890", True),
+        ("0xABCDEF1234567890", True),
+        ("0xAbCdEf1234567890", True),
+        ("12345", True),  # odd length
+        ("0x12345", True),  # odd length
+        ("123456xx", False),  # non-hex character
+        ("0x123456xx", False),  # non-hex character
+        ("0\u0080", False),  # triggers different exceptions in py2 and py3
     ),
 )
 def test_is_hex(value, expected):
@@ -29,7 +27,7 @@ def test_is_hex(value, expected):
     assert actual is expected
 
 
-@pytest.mark.parametrize('value', (b'', 123, {}, lambda: None))
+@pytest.mark.parametrize("value", (b"", 123, {}, lambda: None))
 def test_is_hex_rejects_non_text_types(value):
     with pytest.raises(TypeError):
         is_hex(value)

--- a/tests/module-loading-utils/test_import_string.py
+++ b/tests/module-loading-utils/test_import_string.py
@@ -1,10 +1,7 @@
-from eth_utils.decorators import (
-    combomethod,
-)
-from eth_utils.module_loading import (
-    import_string,
-)
+from eth_utils.decorators import combomethod
+from eth_utils.module_loading import import_string
+
 
 def test_import_string():
-    imported_combomethod = import_string('eth_utils.decorators.combomethod')
+    imported_combomethod = import_string("eth_utils.decorators.combomethod")
     assert imported_combomethod is combomethod

--- a/tests/types-utils/test_types_utils.py
+++ b/tests/types-utils/test_types_utils.py
@@ -20,7 +20,7 @@ from eth_utils.types import (
         ("0x3", False),
         (True, False),
         (False, False),
-    ]
+    ],
 )
 def test_is_integer(value, expected):
     assert is_integer(value) == expected
@@ -36,7 +36,7 @@ def test_is_integer(value, expected):
         (None, False),
         (3, False),
         ({}, False),
-    ]
+    ],
 )
 def test_is_string(value, expected):
     assert is_string(value) == expected
@@ -52,7 +52,7 @@ def test_is_string(value, expected):
         ("0x3", False),
         ({}, True),
         ({"test": 3}, True),
-    ]
+    ],
 )
 def test_is_dict(value, expected):
     assert is_dict(value) == expected
@@ -68,7 +68,7 @@ def test_is_dict(value, expected):
         ("0x3", False),
         (True, True),
         (False, True),
-    ]
+    ],
 )
 def test_is_boolean(value, expected):
     assert is_boolean(value) == expected
@@ -94,7 +94,7 @@ def test_is_boolean(value, expected):
         ((None,), True),
         ((tuple(),), True),
         (((1, 2),), True),
-    ]
+    ],
 )
 def test_is_list_like(value, expected):
     assert is_list_like(value) == expected
@@ -120,7 +120,7 @@ def test_is_list_like(value, expected):
         ((None,), False),
         ((tuple(),), False),
         (((1, 2),), False),
-    ]
+    ],
 )
 def test_is_list(value, expected):
     assert is_list(value) == expected
@@ -146,7 +146,7 @@ def test_is_list(value, expected):
         ((None,), True),
         ((tuple(),), True),
         (((1, 2),), True),
-    ]
+    ],
 )
 def test_is_tuple(value, expected):
     assert is_tuple(value) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,10 @@ basepython=
     pypy3: pypy3
 
 [testenv:lint]
+whitelist_externals=black
 basepython=python
 extras=lint
 commands=
     flake8 {toxinidir}/eth_utils
     mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p eth_utils
+    black --check --diff {toxinidir}/eth_utils/ --check --diff {toxinidir}/tests/

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ basepython=
 
 [testenv:lint]
 whitelist_externals=black
-basepython=python
+basepython=python3.6
 extras=lint
 commands=
     flake8 {toxinidir}/eth_utils


### PR DESCRIPTION
### What was wrong?
We've been using `black` in `py-ethpm`, and personally, I love how simple and effective it is to use, and the continuity it brings to a library (shoutout @cburgdorf for the recommendation) - even if I don't personally agree with 100% of its linting rules.

@pipermerriam suggested importing it into the `eth-utils` library, here's what that would look like. 

Though fair warning, from what I can tell there's no way to configure black to ignore certain rules, so it's either surrender your styling to black or go back to looking up individual style guide rules.

### How was it fixed?
Added black as a dependency and added black command to the tox linting environment.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/45060131-e4169d80-b05b-11e8-953c-94f49a00f506.png)

