### PR TITLE
Christoph/feat/relax eth typing bound

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0-beta.0
+current_version = 1.3.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-alpha.0
+current_version = 1.3.0-beta.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+v1.3.0
+--------------
+
+- Misc
+
+  - Fix linting issues
+
 v1.3.0-beta.0
 --------------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v2.0.0-alpha.0
+v1.3.0-beta.0
 --------------
 
 - Misc

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Iterable
 
 from .types import is_text
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require['dev'] = (
 setup(
     name='eth-utils',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version='1.3.0-beta.0',
+    version='1.3.0',
     description="""Common utility functions for ethereum codebases.""",
     long_description_markdown_filename='README.md',
     author='Piper Merriam',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-hash>=0.1.0,<1.0.0",
-        "eth-typing>=2.0.0,<3.0.0",
+        "eth-typing>=1.0.0,<3.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",
         "cytoolz>=0.8.2,<1.0.0;implementation_name=='cpython'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require['dev'] = (
 setup(
     name='eth-utils',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version='2.0.0-alpha.0',
+    version='1.3.0-beta.0',
     description="""Common utility functions for ethereum codebases.""",
     long_description_markdown_filename='README.md',
     author='Piper Merriam',

--- a/tests/conversion-utils/test_conversions.py
+++ b/tests/conversion-utils/test_conversions.py
@@ -63,7 +63,7 @@ def test_to_text_identity():
         (b"cowm\xc3\xb6", "cowmö"),
         (bytearray(b"cowm\xc3\xb6"), "cowmö"),
         ("0x636f776dc3b6", "cowmö"),
-        (0x636f776dc3b6, "cowmö"),
+        (0x636F776DC3B6, "cowmö"),
         ("0xa", "\n"),
     ),
 )


### PR DESCRIPTION
### What was wrong?

Cutting a new major release forces us to cut new major releases for several other projects, which in turn seems relatively expensive in terms of cost/benefit, based on the assumption that the update should hardly cause much problems itself.

### How was it fixed?

- relax the dependency again `eth_typing to allow everything from 1.x to 2.x
- cut a new `1.3.0-beta.0` release with the intend to remove the `2.0.0-alpha.0` release if this proofs as a viable solution.

#### Cute Animal Picture

![Cute animal picture]()
