### PR TITLE
Enable discovery of type hints as per PEP561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'eth_utils': ['py.typed']},
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
### What was wrong?
Fixes #140 


### How was it fixed?
Added a `py.typed` file and made the corresponding change in `setup.py`


#### Cute Animal Picture

![Cute animal picture](https://img.purch.com/w/660/aHR0cDovL3d3dy5saXZlc2NpZW5jZS5jb20vaW1hZ2VzL2kvMDAwLzAyNC8xODgvb3JpZ2luYWwvc2xlZXBpbmcta2l0dGVuLmpwZw==)
