### PR TITLE
Fix incorrect equality check

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -70,7 +70,7 @@ def validate_conversion_arguments(to_wrap):
         if kwargs:
             _validate_supported_kwarg(kwargs)
 
-        if len(args) is 0 and "primitive" not in kwargs:
+        if len(args) == 0 and "primitive" not in kwargs:
             _assert_hexstr_or_text_kwarg_is_text_type(**kwargs)
         return to_wrap(*args, **kwargs)
 


### PR DESCRIPTION
### What was wrong?

Some minor lint found its way into the project.  Incorrectly using `is` for numerical equality check.

### How was it fixed?

Changed to `==`.

#### Cute Animal Picture

![Cute animal picture](http://sites.psu.edu/jee1117/wp-content/uploads/sites/13114/2014/06/2014-06-13-1720131.jpg)
