### PR TITLE
Tox config

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -70,7 +70,7 @@ def validate_conversion_arguments(to_wrap):
         if kwargs:
             _validate_supported_kwarg(kwargs)
 
-        if len(args) is 0 and "primitive" not in kwargs:
+        if len(args) == 0 and "primitive" not in kwargs:
             _assert_hexstr_or_text_kwarg_is_text_type(**kwargs)
         return to_wrap(*args, **kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ basepython=
     py36: python3.6
     mypy: mypy
     pypy3: pypy3
+whitelist_externals=make
 
 
 [testenv:lint]


### PR DESCRIPTION
### What was wrong?

Tox was complaining about `make` being an external command.

### How was it fixed?

Explicitly whitelisted it.

#### Cute Animal Picture

![Cute animal picture](https://media.buzzle.com/media/images-en/photos/mammals/dogs/1200-93445521-portrait-of-a-huskies.jpg)
