### PR TITLE
Add numeric clamp utility

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1286,6 +1286,31 @@ hexidecimal digits.
     '0001..1e1f'
 
 
+Numeric Utils
+~~~~~~~~~~~~~
+
+``clamp(lower_bound, upper_bound, value)`` -> result
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Returns ``value`` clamped within the inclusive range defined by ``[lower_bound,
+upper_bound]``.  The value can be any number type that supports ``<`` and ``>``
+comparisons against the provided bounds.
+
+.. doctest::
+
+   >>> from eth_utils import clamp
+   >>> clamp(5, 7, 4)
+   5
+   >>> clamp(5, 7, 5)
+   5
+   >>> clamp(5, 7, 6)
+   6
+   >>> clamp(5, 7, 7)
+   7
+   >>> clamp(5, 7, 8)
+   7
+
+
 Type Utils
 ~~~~~~~~~~
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -65,6 +65,7 @@ from .hexadecimal import (  # noqa: F401
 )
 from .humanize import humanize_hash, humanize_seconds  # noqa: F401
 from .module_loading import import_string  # noqa: F401
+from .numeric import clamp  # noqa: F401
 from .types import (  # noqa: F401
     is_boolean,
     is_bytes,

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -12,6 +12,7 @@ from eth_utils import (
     apply_one_of_formatters,
     apply_to_return_value,
     big_endian_to_int,
+    clamp,
     combine_argument_formatters,
     combomethod,
     decode_hex,
@@ -83,5 +84,6 @@ hexstr_if_str = curry(hexstr_if_str)
 is_same_address = curry(is_same_address)
 text_if_str = curry(text_if_str)
 to_wei = curry(to_wei)
+clamp = curry(clamp)
 
 del curry

--- a/eth_utils/numeric.py
+++ b/eth_utils/numeric.py
@@ -1,7 +1,18 @@
-import numbers
-from typing import TypeVar
+from abc import abstractmethod, ABC
+from typing import Any, TypeVar
 
-TValue = TypeVar("TValue", bound=numbers.Real)
+
+class Comparable(ABC):
+    @abstractmethod
+    def __lt__(self, other: Any) -> bool:
+        ...
+
+    @abstractmethod
+    def __gt__(self, other: Any) -> bool:
+        ...
+
+
+TValue = TypeVar("TValue", bound=Comparable)
 
 
 def clamp(lower_bound: TValue, upper_bound: TValue, value: TValue) -> TValue:

--- a/eth_utils/numeric.py
+++ b/eth_utils/numeric.py
@@ -1,0 +1,13 @@
+import numbers
+from typing import TypeVar
+
+TValue = TypeVar("TValue", bound=numbers.Real)
+
+
+def clamp(lower_bound: TValue, upper_bound: TValue, value: TValue) -> TValue:
+    if value < lower_bound:
+        return lower_bound
+    elif value > upper_bound:
+        return upper_bound
+    else:
+        return value

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ extras_require = {
 }
 
 extras_require['dev'] = (
-    extras_require['dev'] +
-    extras_require['doc'] +
-    extras_require['lint'] +
-    extras_require['test'] +
+    extras_require['dev'] +  # noqa: W504
+    extras_require['doc'] +  # noqa: W504
+    extras_require['lint'] +  # noqa: W504
+    extras_require['test'] +  # noqa: W504
     extras_require['deploy']
 )
 

--- a/tests/numeric-utils/test_clamp.py
+++ b/tests/numeric-utils/test_clamp.py
@@ -1,0 +1,18 @@
+import pytest
+
+from eth_utils.numeric import clamp
+
+
+@pytest.mark.parametrize(
+    "lower_bound,upper_bound,value,expected",
+    (
+        (5, 7, 4, 5),
+        (5, 7, 5, 5),
+        (5, 7, 6, 6),
+        (5, 7, 7, 7),
+        (5, 7, 8, 7),
+    ),
+)
+def test_numeric_clamp_utility(lower_bound, upper_bound, value, expected):
+    result = clamp(lower_bound, upper_bound, value)
+    assert result == expected

--- a/tests/numeric-utils/test_clamp.py
+++ b/tests/numeric-utils/test_clamp.py
@@ -5,13 +5,7 @@ from eth_utils.numeric import clamp
 
 @pytest.mark.parametrize(
     "lower_bound,upper_bound,value,expected",
-    (
-        (5, 7, 4, 5),
-        (5, 7, 5, 5),
-        (5, 7, 6, 6),
-        (5, 7, 7, 7),
-        (5, 7, 8, 7),
-    ),
+    ((5, 7, 4, 5), (5, 7, 5, 5), (5, 7, 6, 6), (5, 7, 7, 7), (5, 7, 8, 7)),
 )
 def test_numeric_clamp_utility(lower_bound, upper_bound, value, expected):
     result = clamp(lower_bound, upper_bound, value)

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ whitelist_externals=black
 basepython=python3.6
 extras=lint
 commands=
-    flake8 {toxinidir}/eth_utils
+    flake8 {toxinidir}/eth_utils setup.py
     mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p eth_utils
     black --check --diff {toxinidir}/eth_utils/ --check --diff {toxinidir}/tests/
     py.test {posargs:tests}/functional-utils/type_inference_tests.py


### PR DESCRIPTION
### What was wrong?

It's not very easy to read a numeric clamp using the built-in primatives.

```
val = min(5, max(8, value))
val = tuple(sorted((5, 8) + (value,)))[1]
...
```

### How was it fixed?

Added a new utility `clamp(...)` which does this.

#### Cute Animal Picture

![AdobeStock_94866073-770x405](https://user-images.githubusercontent.com/824194/56226830-52c7ca80-6031-11e9-9ed5-25ea4fb50023.jpg)
