### PR TITLE
Fix type checking issue with to_dict and to_ordered_dict

### DIFF
--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -34,7 +34,7 @@ def to_hex(
         )
 
     if is_integer(primitive):
-        return HexStr(hex(primitive))
+        return HexStr(hex(primitive))  # type: ignore
 
     raise TypeError(
         "Unsupported type: '{0}'.  Must be one of: bool, str, bytes, bytearray"
@@ -66,7 +66,7 @@ def to_int(
     elif isinstance(primitive, str):
         raise TypeError("Pass in strings with keyword hexstr or text")
     else:
-        return int(primitive)
+        return int(primitive)  # type: ignore
 
 
 @validate_conversion_arguments
@@ -106,7 +106,7 @@ def to_text(
     elif isinstance(primitive, (bytes, bytearray)):
         return primitive.decode("utf-8")
     elif is_integer(primitive):
-        byte_encoding = int_to_big_endian(primitive)
+        byte_encoding = int_to_big_endian(primitive)  # type: ignore
         return to_text(byte_encoding)
     raise TypeError("Expected an int, bytes, bytearray or hexstr.")
 
@@ -122,10 +122,9 @@ def text_if_str(
     :param text_or_primitive bytes, str, int: value to convert
     """
     if isinstance(text_or_primitive, str):
-        (primitive, text) = (None, text_or_primitive)
+        return to_type(text=text_or_primitive)
     else:
-        (primitive, text) = (text_or_primitive, None)
-    return to_type(primitive, text=text)
+        return to_type(text_or_primitive)
 
 
 def hexstr_if_str(
@@ -139,13 +138,12 @@ def hexstr_if_str(
     :param hexstr_or_primitive bytes, str, int: value to convert
     """
     if isinstance(hexstr_or_primitive, str):
-        (primitive, hexstr) = (None, hexstr_or_primitive)
-        if remove_0x_prefix(hexstr) and not is_hex(hexstr):
+        if remove_0x_prefix(hexstr_or_primitive) and not is_hex(hexstr_or_primitive):
             raise ValueError(
                 "when sending a str, it must be a hex string. Got: {0!r}".format(
                     hexstr_or_primitive
                 )
             )
+        return to_type(hexstr=hexstr_or_primitive)
     else:
-        (primitive, hexstr) = (hexstr_or_primitive, None)
-    return to_type(primitive, hexstr=hexstr)
+        return to_type(hexstr_or_primitive)

--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union
+from typing import Callable, Union, cast
 
 from .decorators import validate_conversion_arguments
 from .encoding import big_endian_to_int, int_to_big_endian
@@ -34,7 +34,7 @@ def to_hex(
         )
 
     if is_integer(primitive):
-        return HexStr(hex(primitive))  # type: ignore
+        return HexStr(hex(cast(int, primitive)))
 
     raise TypeError(
         "Unsupported type: '{0}'.  Must be one of: bool, str, bytes, bytearray"
@@ -65,8 +65,13 @@ def to_int(
         return big_endian_to_int(primitive)
     elif isinstance(primitive, str):
         raise TypeError("Pass in strings with keyword hexstr or text")
+    elif isinstance(primitive, (int, bool)):
+        return int(primitive)
     else:
-        return int(primitive)  # type: ignore
+        raise TypeError(
+            "Invalid type.  Expected one of int/bool/str/bytes/bytearray.  Got "
+            "{0}".format(type(primitive))
+        )
 
 
 @validate_conversion_arguments

--- a/eth_utils/functional.py
+++ b/eth_utils/functional.py
@@ -63,10 +63,10 @@ to_set = apply_to_return_value(
 )  # type: Callable[[Callable[..., Iterable[TVal]]], Callable[..., Set[TVal]]]  # noqa: E501
 to_dict = apply_to_return_value(
     dict
-)  # type: Callable[[Callable[..., Iterable[Union[Mapping[TVal, TKey], Tuple[TVal, TKey]]]]], Callable[..., Dict[TKey, TVal]]]  # noqa: E501
+)  # type: Callable[[Callable[..., Iterable[Union[Mapping[TKey, TVal], Tuple[TKey, TVal]]]]], Callable[..., Dict[TKey, TVal]]]  # noqa: E501
 to_ordered_dict = apply_to_return_value(
     collections.OrderedDict
-)  # type: Callable[[Callable[..., Iterable[Union[Mapping[TVal, TKey], Tuple[TVal, TKey]]]]], Callable[..., collections.OrderedDict[TKey, TVal]]]  # noqa: E501
+)  # type: Callable[[Callable[..., Iterable[Union[Mapping[TKey, TVal], Tuple[TKey, TVal]]]]], Callable[..., collections.OrderedDict[TKey, TVal]]]  # noqa: E501
 sort_return = _compose(to_tuple, apply_to_return_value(sorted))
 flatten_return = _compose(
     to_tuple, apply_to_return_value(itertools.chain.from_iterable)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'lint': [
         'black>=18.6b4,<19',
         'flake8>=3.5.0,<4.0.0',
-        'mypy<0.600',
+        'mypy<0.701',
         'pytest>=3.4.1,<4.0.0',
     ],
     'test': [

--- a/tests/mypy_typing_of_functional_utils.py
+++ b/tests/mypy_typing_of_functional_utils.py
@@ -1,0 +1,95 @@
+from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
+
+from eth_utils import (
+    flatten_return,
+    reversed_return,
+    sort_return,
+    to_dict,
+    to_list,
+    to_ordered_dict,
+    to_set,
+    to_tuple,
+)
+
+if TYPE_CHECKING:
+    from collections import OrderedDict  # noqa: F401
+
+
+@to_tuple
+def typing_to_tuple() -> Iterable[int]:
+    yield 1
+    yield 2
+    yield 3
+
+
+v_tuple: Tuple[int, ...] = typing_to_tuple()
+
+
+@to_list
+def typing_to_list() -> Iterable[int]:
+    yield 1
+    yield 2
+    yield 3
+
+
+v_list: List[int] = typing_to_list()
+
+
+@to_set
+def typing_to_set() -> Iterable[int]:
+    yield 1
+    yield 2
+    yield 3
+
+
+v_set: Set[int] = typing_to_set()
+
+
+@to_dict
+def typing_to_dict() -> Iterable[Tuple[str, int]]:
+    yield ("a", 1)
+    yield ("b", 2)
+    yield ("c", 3)
+
+
+v_dict: Dict[str, int] = typing_to_dict()
+
+
+@to_ordered_dict
+def typing_to_ordered_dict() -> Iterable[Tuple[str, int]]:
+    yield ("a", 1)
+    yield ("b", 2)
+    yield ("c", 3)
+
+
+v_ordered_dict: "OrderedDict[str, int]" = typing_to_ordered_dict()
+
+
+@flatten_return
+def typing_flatten_return() -> Iterable[Tuple[int, ...]]:
+    yield (1, 2)
+    yield (3, 4)
+    yield (5, 6)
+
+
+v_flatten_return: Tuple[int, ...] = typing_flatten_return()
+
+
+@reversed_return
+def typing_reversed_return() -> Iterable[int]:
+    yield 1
+    yield 2
+    yield 3
+
+
+v_reversed_return: Tuple[int] = typing_reversed_return()
+
+
+@sort_return
+def typing_sorted_return() -> Iterable[int]:
+    yield 1
+    yield 2
+    yield 3
+
+
+v_sorted_return: Tuple[int] = typing_sorted_return()

--- a/tests/mypy_typing_of_functional_utils.py
+++ b/tests/mypy_typing_of_functional_utils.py
@@ -1,15 +1,6 @@
 from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
 
-from eth_utils import (
-    flatten_return,
-    reversed_return,
-    sort_return,
-    to_dict,
-    to_list,
-    to_ordered_dict,
-    to_set,
-    to_tuple,
-)
+from eth_utils import to_dict, to_list, to_ordered_dict, to_set, to_tuple
 
 if TYPE_CHECKING:
     from collections import OrderedDict  # noqa: F401
@@ -63,33 +54,3 @@ def typing_to_ordered_dict() -> Iterable[Tuple[str, int]]:
 
 
 v_ordered_dict: "OrderedDict[str, int]" = typing_to_ordered_dict()
-
-
-@flatten_return
-def typing_flatten_return() -> Iterable[Tuple[int, ...]]:
-    yield (1, 2)
-    yield (3, 4)
-    yield (5, 6)
-
-
-v_flatten_return: Tuple[int, ...] = typing_flatten_return()
-
-
-@reversed_return
-def typing_reversed_return() -> Iterable[int]:
-    yield 1
-    yield 2
-    yield 3
-
-
-v_reversed_return: Tuple[int] = typing_reversed_return()
-
-
-@sort_return
-def typing_sorted_return() -> Iterable[int]:
-    yield 1
-    yield 2
-    yield 3
-
-
-v_sorted_return: Tuple[int] = typing_sorted_return()

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,4 @@ commands=
     mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p eth_utils
     black --check --diff {toxinidir}/eth_utils/ --check --diff {toxinidir}/tests/
     py.test {posargs:tests}/functional-utils/type_inference_tests.py
+    mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs tests/mypy_typing_of_functional_utils.py


### PR DESCRIPTION
### What was wrong?

The `to_dict` and `to_ordered_dict` had incorrect type hints.

Also updated to new `mypy` version that has some nice improvements

### How was it fixed?

Added a test for each of the `to_thing` decorators to validate they do indeed preserve type data  correctly.

#### Cute Animal Picture

![maxresdefault](https://user-images.githubusercontent.com/824194/56304395-4445e580-60fb-11e9-975e-b6650596e047.jpg)
