### PR TITLE
Make denoms a real class

### DIFF
--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -7,7 +7,30 @@ from .types import is_integer, is_string
 from .units import units
 
 
-denoms = type("denoms", (object,), {key: int(value) for key, value in units.items()})
+class denoms:
+    wei = int(units["wei"])
+    kwei = int(units["kwei"])
+    babbage = int(units["babbage"])
+    femtoether = int(units["femtoether"])
+    mwei = int(units["mwei"])
+    lovelace = int(units["lovelace"])
+    picoether = int(units["picoether"])
+    gwei = int(units["gwei"])
+    shannon = int(units["shannon"])
+    nanoether = int(units["nanoether"])
+    nano = int(units["nano"])
+    szabo = int(units["szabo"])
+    microether = int(units["microether"])
+    micro = int(units["micro"])
+    finney = int(units["finney"])
+    milliether = int(units["milliether"])
+    milli = int(units["milli"])
+    ether = int(units["ether"])
+    kether = int(units["kether"])
+    grand = int(units["grand"])
+    mether = int(units["mether"])
+    gether = int(units["gether"])
+    tether = int(units["tether"])
 
 
 MIN_WEI = 0

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import (
 extras_require = {
     'lint': [
         'black>=18.6b4,<19',
-        'flake8>=3.5.0,<4.0.0',
-        'mypy<0.701',
+        'flake8>=3.7.0,<4.0.0',
+        'mypy==0.701',
         'pytest>=3.4.1,<4.0.0',
     ],
     'test': [

--- a/tests/currency-utils/test_denoms_obj.py
+++ b/tests/currency-utils/test_denoms_obj.py
@@ -1,0 +1,7 @@
+from eth_utils import denoms
+from eth_utils.units import units
+
+
+def test_all_units_are_on_denoms_object():
+    for name in units.keys():
+        assert hasattr(denoms, name)

--- a/tests/mypy_typing_of_functional_utils.py
+++ b/tests/mypy_typing_of_functional_utils.py
@@ -1,6 +1,6 @@
 from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
 
-from eth_utils import to_dict, to_list, to_ordered_dict, to_set, to_tuple
+from eth_utils import denoms, to_dict, to_list, to_ordered_dict, to_set, to_tuple
 
 if TYPE_CHECKING:
     from collections import OrderedDict  # noqa: F401
@@ -54,3 +54,6 @@ def typing_to_ordered_dict() -> Iterable[Tuple[str, int]]:
 
 
 v_ordered_dict: "OrderedDict[str, int]" = typing_to_ordered_dict()
+
+# verifies that the denoms object is properly typed.
+ether: int = denoms.ether


### PR DESCRIPTION
### What was wrong?

The `eth_utils.denoms` object doesn't have type information for it's attributes since it is dynamically created using `type(...)`

### How was it fixed?

Updated it to explicitly name all of the units and added a test to ensure that all units from `eth_utils.units` are present on the class.

#### Cute Animal Picture

![unlikely-animals-sleeping-together-posted-at-awesomelycute com-9](https://user-images.githubusercontent.com/824194/56509115-581a8e80-64e3-11e9-8b25-df99d398514a.jpg)

