### PR TITLE
Fix type hinting for replace_exceptions

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Type
 
 from .types import is_text
 
@@ -95,7 +95,7 @@ def return_arg_type(at_position):
 
 
 def replace_exceptions(
-    old_to_new_exceptions: Dict[BaseException, BaseException]
+    old_to_new_exceptions: Dict[Type[BaseException], Type[BaseException]]
 ) -> Callable[..., Any]:
     """
     Replaces old exceptions with new exceptions to be raised in their place.
@@ -107,17 +107,17 @@ def replace_exceptions(
         # String type b/c pypy3 throws SegmentationFault with Iterable as arg on nested fn
         # Ignore so we don't have to import `Iterable`
         def wrapper(
-            *args: "Iterable[Any]", **kwargs: "Dict[str, Any]"  # type: ignore
+            *args: Iterable[Any], **kwargs: Dict[str, Any]
         ) -> Callable[..., Any]:
             try:
                 return to_wrap(*args, **kwargs)
-            except old_exceptions as e:  # type: ignore
+            except old_exceptions as err:
                 try:
-                    raise old_to_new_exceptions[type(e)] from e  # type: ignore
+                    raise old_to_new_exceptions[type(err)] from err
                 except KeyError:
                     raise TypeError(
-                        "could not look up new exception to use for %r" % e
-                    ) from e
+                        "could not look up new exception to use for %r" % err
+                    ) from err
 
         return wrapper
 

--- a/tests/mypy_typing_of_functional_utils.py
+++ b/tests/mypy_typing_of_functional_utils.py
@@ -1,6 +1,14 @@
 from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
 
-from eth_utils import denoms, to_dict, to_list, to_ordered_dict, to_set, to_tuple
+from eth_utils import (
+    denoms,
+    to_dict,
+    to_list,
+    to_ordered_dict,
+    to_set,
+    to_tuple,
+    replace_exceptions,
+)
 
 if TYPE_CHECKING:
     from collections import OrderedDict  # noqa: F401
@@ -57,3 +65,8 @@ v_ordered_dict: "OrderedDict[str, int]" = typing_to_ordered_dict()
 
 # verifies that the denoms object is properly typed.
 ether: int = denoms.ether
+
+
+@replace_exceptions({ValueError: TypeError})
+def example_replace_exceptions():
+    raise ValueError("The base exception")

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ basepython=python3.6
 extras=lint
 commands=
     flake8 {toxinidir}/eth_utils setup.py
-    mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p eth_utils
+    mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs --warn-unused-ignore -p eth_utils
+    mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs tests/mypy_typing_of_functional_utils.py
     black --check --diff {toxinidir}/eth_utils/ --check --diff {toxinidir}/tests/
     py.test {posargs:tests}/functional-utils/type_inference_tests.py
-    mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs tests/mypy_typing_of_functional_utils.py


### PR DESCRIPTION
### What was wrong?

The `replace_exceptions` helper had incorrect type hints.

### How was it fixed?

Fixed type hints to expect classes instead of instances.

#### Cute Animal Picture

![goats-goats-goats](https://user-images.githubusercontent.com/824194/56512780-97e67380-64ed-11e9-87ef-51ac2056c57e.jpeg)

