### PR TITLE
Use eth-typing types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36
+  py36-typing1:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-typing1
   pypy3:
     <<: *common
     docker:
@@ -81,4 +87,5 @@ workflows:
       - lint
       - py35
       - py36
+      - py36-typing1
       - pypy3

--- a/eth_utils/typing/misc.py
+++ b/eth_utils/typing/misc.py
@@ -1,13 +1,23 @@
 from typing import NewType, TypeVar, Union
+import warnings
 
 from eth_typing import Address
 
+try:
+    from eth_typing import AnyAddress, ChecksumAddress, HexAddress, HexStr, Primitives
+except ImportError:
+    warnings.warn("Old version of 'eth-typing', please update.")
 
-HexAddress = NewType("HexAddress", str)  # for hex encoded addresses
-ChecksumAddress = NewType(
-    "ChecksumAddress", HexAddress
-)  # for hex addresses with checksums
-AnyAddress = TypeVar("AnyAddress", Address, HexAddress, ChecksumAddress)
-HexStr = NewType("HexStr", str)
-Primitives = Union[bytes, int, bool]
+    # for hex encoded addresses
+    HexAddress = NewType("HexAddress", str)  # type: ignore
+    ChecksumAddress = NewType(  # type: ignore
+        "ChecksumAddress", HexAddress
+    )  # for hex addresses with checksums
+    AnyAddress = TypeVar(  # type: ignore
+        "AnyAddress", Address, HexAddress, ChecksumAddress
+    )
+    HexStr = NewType("HexStr", str)  # type: ignore
+    Primitives = Union[bytes, int, bool]  # type: ignore
+
+
 T = TypeVar("T")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
     py{35,36,py3}
+    py36-typing1
     lint
     doctest
 
@@ -16,6 +17,7 @@ commands=
     doctest: make -C {toxinidir}/docs doctest
 deps=
     eth-hash[pycryptodome]
+    typing1: eth-typing<2
 extras= 
     test
     doctest: doc


### PR DESCRIPTION
### What was wrong?

`eth_utils` defined own type aliases and doesn't use the ones that `eth_typing` provides. See #160 

### How was it fixed?

Used the type aliases from `eth-typing`.

This is a second attempt, according to the comment: https://github.com/ethereum/eth-utils/pull/161#issuecomment-495556352

#### Cute Animal Picture

![Cute animal picture](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fimages-cdn.9gag.com%2Fphoto%2F5533082_700b_v1.jpg&f=1)