### PR TITLE
show that clamp doesn't work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ common: &common
           - v1-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: upgrade pip
-        command: pip install --upgrade pip
+        command: pip install --upgrade --user pip
     - run:
         name: install dependencies
         command: pip install --user tox

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ clean-pyc:
 lint:
 	flake8 eth_utils
 
+lint-roll:
+	isort --recursive eth_utils tests
+	black eth_utils tests
+	$(MAKE) lint
+
 test:
 	py.test tests
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -1,6 +1,7 @@
-import pkg_resources
 import sys
 import warnings
+
+import pkg_resources
 
 from .abi import (  # noqa: F401
     event_abi_to_log_topic,
@@ -32,12 +33,12 @@ from .applicators import (  # noqa: F401
     combine_argument_formatters,
 )
 from .conversions import (  # noqa: F401
+    hexstr_if_str,
+    text_if_str,
     to_bytes,
     to_hex,
     to_int,
     to_text,
-    hexstr_if_str,
-    text_if_str,
 )
 from .crypto import keccak  # noqa: F401
 from .currency import denoms, from_wei, to_wei  # noqa: F401
@@ -65,10 +66,10 @@ from .hexadecimal import (  # noqa: F401
 )
 from .humanize import humanize_hash, humanize_ipfs_uri, humanize_seconds  # noqa: F401
 from .logging import (  # noqa: F401
-    setup_DEBUG2_logging,
     ExtendedDebugLogger,
-    HasLogger,
     HasExtendedDebugLogger,
+    HasLogger,
+    setup_DEBUG2_logging,
 )
 from .module_loading import import_string  # noqa: F401
 from .numeric import clamp  # noqa: F401
@@ -85,7 +86,6 @@ from .types import (  # noqa: F401
     is_text,
     is_tuple,
 )
-
 
 if sys.version_info.major < 3:
     warnings.simplefilter("always", DeprecationWarning)

--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -1,8 +1,8 @@
 from typing import Any, AnyStr
 
+from .conversions import hexstr_if_str, to_hex
 from .crypto import keccak
 from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hex, remove_0x_prefix
-from .conversions import hexstr_if_str, to_hex
 from .types import is_bytes, is_text
 from .typing import Address, AnyAddress, ChecksumAddress, HexAddress
 

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,11 +1,9 @@
+from typing import Any, Callable, Dict, Generator, List, Tuple
 import warnings
 
-from typing import Any, Callable, Dict, Generator, List, Tuple
-
-from .toolz import compose, curry
 from .decorators import return_arg_type
 from .functional import to_dict
-
+from .toolz import compose, curry
 
 Formatters = Callable[[List[Any]], List[Any]]
 

--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -1,6 +1,5 @@
 import decimal
 from decimal import localcontext
-
 from typing import Union
 
 from .types import is_integer, is_string

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -1,7 +1,9 @@
 # flake8: noqa
-from eth_utils.toolz import curry
-
 from eth_utils import (
+    ExtendedDebugLogger,
+    HasExtendedDebugLogger,
+    HasLogger,
+    ValidationError,
     add_0x_prefix,
     apply_formatter_at_index,
     apply_formatter_if,
@@ -20,13 +22,10 @@ from eth_utils import (
     encode_hex,
     event_abi_to_log_topic,
     event_signature_to_log_topic,
-    ExtendedDebugLogger,
     flatten_return,
     from_wei,
     function_abi_to_4byte_selector,
     function_signature_to_4byte_selector,
-    HasExtendedDebugLogger,
-    HasLogger,
     hexstr_if_str,
     humanize_hash,
     humanize_ipfs_uri,
@@ -74,8 +73,8 @@ from eth_utils import (
     to_text,
     to_tuple,
     to_wei,
-    ValidationError,
 )
+from eth_utils.toolz import curry
 
 apply_formatter_at_index = curry(apply_formatter_at_index)
 apply_formatter_if = curry(apply_formatter_if)

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -1,6 +1,5 @@
 import functools
 import itertools
-
 from typing import Any, Callable, Dict, Iterable, Type
 
 from .types import is_text

--- a/eth_utils/functional.py
+++ b/eth_utils/functional.py
@@ -16,7 +16,6 @@ from typing import (  # noqa: F401
 
 from .toolz import compose as _compose
 
-
 T = TypeVar("T")
 
 

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -3,7 +3,6 @@
 import binascii
 import codecs
 import string
-
 from typing import Any, AnyStr
 
 from .types import is_string, is_text

--- a/eth_utils/humanize.py
+++ b/eth_utils/humanize.py
@@ -1,7 +1,7 @@
 from typing import Any, Iterator, Tuple, Union
 from urllib import parse
 
-from eth_typing import Hash32, URI
+from eth_typing import URI, Hash32
 
 from .toolz import take
 

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import Any, Type, Iterator
+from typing import Any, Iterator, Type
 
 from .toolz import assoc
 

--- a/eth_utils/module_loading.py
+++ b/eth_utils/module_loading.py
@@ -1,5 +1,4 @@
 from importlib import import_module
-
 from typing import Any
 
 

--- a/eth_utils/numeric.py
+++ b/eth_utils/numeric.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod, ABC
-from typing import Any, TypeVar
+import decimal
+import numbers
+from typing import Any, TypeVar, Union
 
 
 class Comparable(ABC):
@@ -12,7 +14,10 @@ class Comparable(ABC):
         ...
 
 
-TValue = TypeVar("TValue", bound=Comparable)
+TComparable = Union[Comparable, numbers.Real, int, float, decimal.Decimal]
+
+
+TValue = TypeVar("TValue", bound=TComparable)
 
 
 def clamp(lower_bound: TValue, upper_bound: TValue, value: TValue) -> TValue:

--- a/eth_utils/numeric.py
+++ b/eth_utils/numeric.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 import decimal
 import numbers
 from typing import Any, TypeVar, Union
@@ -21,9 +21,9 @@ TValue = TypeVar("TValue", bound=TComparable)
 
 
 def clamp(lower_bound: TValue, upper_bound: TValue, value: TValue) -> TValue:
-    if value < lower_bound:
+    if value < lower_bound:  # type: ignore
         return lower_bound
-    elif value > upper_bound:
+    elif value > upper_bound:  # type: ignore
         return upper_bound
     else:
         return value

--- a/eth_utils/numeric.py
+++ b/eth_utils/numeric.py
@@ -21,6 +21,13 @@ TValue = TypeVar("TValue", bound=TComparable)
 
 
 def clamp(lower_bound: TValue, upper_bound: TValue, value: TValue) -> TValue:
+    # The `mypy` ignore statements here are due to doing a comparison of
+    # `Union` types which isn't allowed. (per cburgdorf).  This approach was
+    # chosen over using `typing.overload` to define multiple signatures for
+    # each comparison type here since the added value of "proper" typing
+    # doesn't seem to justify the complexity of having a bunch of different
+    # signatures defined.  The external library perspective on this function
+    # should still be adequate under this approach
     if value < lower_bound:  # type: ignore
         return lower_bound
     elif value > upper_bound:  # type: ignore

--- a/eth_utils/types.py
+++ b/eth_utils/types.py
@@ -1,8 +1,6 @@
-import numbers
 import collections
-
+import numbers
 from typing import Any
-
 
 bytes_types = (bytes, bytearray)
 integer_types = (int,)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
     'lint': [
         'black>=18.6b4,<19',
         'flake8>=3.7.0,<4.0.0',
+        "isort==4.3.18",
         'mypy==0.701',
         'pytest>=3.4.1,<4.0.0',
     ],

--- a/tests/abi-utils/test_abi_utils.py
+++ b/tests/abi-utils/test_abi_utils.py
@@ -1,14 +1,13 @@
 import pytest
 
-from eth_utils.hexadecimal import encode_hex
 from eth_utils.abi import (
     _abi_to_signature,
-    function_signature_to_4byte_selector,
-    function_abi_to_4byte_selector,
-    event_signature_to_log_topic,
     event_abi_to_log_topic,
+    event_signature_to_log_topic,
+    function_abi_to_4byte_selector,
+    function_signature_to_4byte_selector,
 )
-
+from eth_utils.hexadecimal import encode_hex
 
 FN_ABI_A = {"name": "tokenLaunched", "type": "function", "inputs": []}
 FN_ABI_B = {"name": "CEILING", "type": "function", "inputs": []}

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -1,8 +1,8 @@
 import collections
+
 import pytest
 
 import eth_utils
-
 from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_if,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import warnings
+
+import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conversion-utils/test_conversions.py
+++ b/tests/conversion-utils/test_conversions.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from eth_utils import to_int, to_bytes, to_hex, to_text
+from eth_utils import to_bytes, to_hex, to_int, to_text
 
 
 @pytest.mark.parametrize(

--- a/tests/currency-utils/test_currency_tools.py
+++ b/tests/currency-utils/test_currency_tools.py
@@ -1,9 +1,10 @@
 import decimal
 
+from hypothesis import given
+from hypothesis import strategies as st
 import pytest
-from hypothesis import given, strategies as st
 
-from eth_utils.currency import units, to_wei, from_wei, MIN_WEI, MAX_WEI
+from eth_utils.currency import MAX_WEI, MIN_WEI, from_wei, to_wei, units
 
 
 @given(

--- a/tests/encoding-utils/test_big_endian_integer.py
+++ b/tests/encoding-utils/test_big_endian_integer.py
@@ -1,8 +1,8 @@
+from hypothesis import given
+from hypothesis import strategies as st
 import pytest
 
-from hypothesis import strategies as st, given
-
-from eth_utils.encoding import int_to_big_endian, big_endian_to_int
+from eth_utils.encoding import big_endian_to_int, int_to_big_endian
 
 
 @pytest.mark.parametrize(

--- a/tests/functional-utils/test_return_value_decorators.py
+++ b/tests/functional-utils/test_return_value_decorators.py
@@ -1,14 +1,14 @@
 import collections
 
 from eth_utils import (
-    to_tuple,
-    to_list,
-    to_dict,
-    to_set,
-    to_ordered_dict,
-    sort_return,
     flatten_return,
     reversed_return,
+    sort_return,
+    to_dict,
+    to_list,
+    to_ordered_dict,
+    to_set,
+    to_tuple,
 )
 
 

--- a/tests/functional-utils/type_inference_tests.py
+++ b/tests/functional-utils/type_inference_tests.py
@@ -1,6 +1,6 @@
-import mypy.api
 from typing import List
 
+import mypy.api
 import pytest
 
 MYPY_ARGS = ["--ignore-missing-imports"]

--- a/tests/humanize-utils/test_humanize_seconds.py
+++ b/tests/humanize-utils/test_humanize_seconds.py
@@ -2,7 +2,6 @@ import pytest
 
 from eth_utils import humanize_seconds
 
-
 SECOND = 1
 MINUTE = 60
 HOUR = 60 * 60

--- a/tests/logging-utils/test_DEBUG2_logging.py
+++ b/tests/logging-utils/test_DEBUG2_logging.py
@@ -2,8 +2,8 @@ import logging
 
 import pytest
 
-from eth_utils.logging import DEBUG2_LEVEL_NUM
 from eth_utils import ExtendedDebugLogger
+from eth_utils.logging import DEBUG2_LEVEL_NUM
 
 
 @pytest.fixture

--- a/tests/logging-utils/test_has_logger_metaclass.py
+++ b/tests/logging-utils/test_has_logger_metaclass.py
@@ -1,5 +1,6 @@
 import logging
-from eth_utils.logging import HasLogger, HasExtendedDebugLogger, ExtendedDebugLogger
+
+from eth_utils.logging import ExtendedDebugLogger, HasExtendedDebugLogger, HasLogger
 
 
 class DefinedAtModule(HasLogger):

--- a/tests/type-checks/mypy_typing_of_functional_utils.py
+++ b/tests/type-checks/mypy_typing_of_functional_utils.py
@@ -1,6 +1,7 @@
 from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
 
 from eth_utils import (
+    clamp,
     denoms,
     to_dict,
     to_list,
@@ -70,3 +71,17 @@ ether: int = denoms.ether
 @replace_exceptions({ValueError: TypeError})
 def example_replace_exceptions():
     raise ValueError("The base exception")
+
+
+def return_value_int(lower: int, upper: int, value: int) -> int:
+    return clamp(lower, upper, value)
+
+
+int_value: int = return_value_int(2, 5, 8)
+
+
+def return_value_float(lower: float, upper: float, value: float) -> float:
+    return clamp(lower, upper, value)
+
+
+float_value: float = return_value_float(2.0, 5.0, 8.0)

--- a/tests/type-checks/mypy_typing_of_functional_utils.py
+++ b/tests/type-checks/mypy_typing_of_functional_utils.py
@@ -1,3 +1,4 @@
+import decimal
 from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
 
 from eth_utils import (
@@ -85,3 +86,16 @@ def return_value_float(lower: float, upper: float, value: float) -> float:
 
 
 float_value: float = return_value_float(2.0, 5.0, 8.0)
+
+
+def return_value_decimal(lower: decimal.Decimal,
+                         upper: decimal.Decimal,
+                         value: decimal.Decimal) -> decimal.Decimal:
+    return clamp(lower, upper, value)
+
+
+decimal_value: decimal.Decimal = return_value_decimal(
+    decimal.Decimal('2.0'),
+    decimal.Decimal('5.0'),
+    decimal.Decimal('8.0'),
+)

--- a/tests/type-checks/mypy_typing_of_functional_utils.py
+++ b/tests/type-checks/mypy_typing_of_functional_utils.py
@@ -1,15 +1,15 @@
 import decimal
-from typing import List, Set, Iterable, Tuple, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Iterable, List, Set, Tuple
 
 from eth_utils import (
     clamp,
     denoms,
+    replace_exceptions,
     to_dict,
     to_list,
     to_ordered_dict,
     to_set,
     to_tuple,
-    replace_exceptions,
 )
 
 if TYPE_CHECKING:
@@ -88,14 +88,12 @@ def return_value_float(lower: float, upper: float, value: float) -> float:
 float_value: float = return_value_float(2.0, 5.0, 8.0)
 
 
-def return_value_decimal(lower: decimal.Decimal,
-                         upper: decimal.Decimal,
-                         value: decimal.Decimal) -> decimal.Decimal:
+def return_value_decimal(
+    lower: decimal.Decimal, upper: decimal.Decimal, value: decimal.Decimal
+) -> decimal.Decimal:
     return clamp(lower, upper, value)
 
 
 decimal_value: decimal.Decimal = return_value_decimal(
-    decimal.Decimal('2.0'),
-    decimal.Decimal('5.0'),
-    decimal.Decimal('8.0'),
+    decimal.Decimal("2.0"), decimal.Decimal("5.0"), decimal.Decimal("8.0")
 )

--- a/tests/type-checks/mypy_typing_of_has_logger.py
+++ b/tests/type-checks/mypy_typing_of_has_logger.py
@@ -1,5 +1,6 @@
 import logging
-from eth_utils import HasLogger, HasExtendedDebugLogger, ExtendedDebugLogger
+
+from eth_utils import ExtendedDebugLogger, HasExtendedDebugLogger, HasLogger
 
 
 def verify_has_logger_type() -> logging.Logger:

--- a/tests/types-utils/test_types_utils.py
+++ b/tests/types-utils/test_types_utils.py
@@ -1,13 +1,13 @@
 import pytest
 
 from eth_utils.types import (
-    is_integer,
     is_boolean,
-    is_string,
-    is_list_like,
-    is_list,
-    is_tuple,
     is_dict,
+    is_integer,
+    is_list,
+    is_list_like,
+    is_string,
+    is_tuple,
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,15 @@ envlist=
     lint
     doctest
 
+[isort]
+force_sort_within_sections=True
+known_third_party=hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+
 [flake8]
 max-line-length= 100
 exclude= tests,venv


### PR DESCRIPTION
### What was wrong?

The typing of the `clamp` utility is broken.

### How was it fixed?

Verbosely expanded the types to include `numbers.Real`, `int`, `float`, and `decimal.Decimal`


#### Cute Animal Picture

![Cute animal picture]()
