### PR TITLE
fixup extended debug logging utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 eth_utils
+	tox -e lint
 
 lint-roll:
 	isort --recursive eth_utils tests

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1378,6 +1378,24 @@ without this, though your logs will be printed with the label ``'Level 8'``.
 .. note::  This function is idempotent
 
 
+``class HasLoggerMeta``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the metaclass which is responsible for adding the logger instance to
+the class.  It exposes two additional APIs.
+
+* ``HasLoggerMeta.replace_logger_class(cls: logging.Logger)``
+
+  Returns a new metaclass which will use the provided logger class.
+
+
+* ``HasLoggerMeta.meta_compat(other: type)``
+
+  Returns a new metaclass that derives from both metaclasses.  This is useful
+  when working in conjunction with ``abc.ABC`` or ``typing.Generic``.
+
+
+
 Numeric Utils
 ~~~~~~~~~~~~~
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -68,7 +68,9 @@ from .humanize import humanize_hash, humanize_ipfs_uri, humanize_seconds  # noqa
 from .logging import (  # noqa: F401
     ExtendedDebugLogger,
     HasExtendedDebugLogger,
+    HasExtendedDebugLoggerMeta,
     HasLogger,
+    HasLoggerMeta,
     setup_DEBUG2_logging,
 )
 from .module_loading import import_string  # noqa: F401

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -2,7 +2,9 @@
 from eth_utils import (
     ExtendedDebugLogger,
     HasExtendedDebugLogger,
+    HasExtendedDebugLoggerMeta,
     HasLogger,
+    HasLoggerMeta,
     ValidationError,
     add_0x_prefix,
     apply_formatter_at_index,

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -63,14 +63,12 @@ class HasLoggerMeta(type):
     def replace_logger_class(
         mcls: Type[THasLoggerMeta], value: Type[logging.Logger]
     ) -> Type[THasLoggerMeta]:
-        # mypy can't tell this is a subclass of `HasLoggerMeta`  # noqa: E501
         return type(mcls.__name__, (mcls,), {"logger_class": value})
 
     @classmethod
     def meta_compat(
         mcls: Type[THasLoggerMeta], other: Type[type]
     ) -> Type[THasLoggerMeta]:
-        # mypy doesn't recognize the bases for this class as valid
         return type(mcls.__name__, (mcls, other), {})
 
 
@@ -85,7 +83,7 @@ class HasLogger(_BaseHasLogger):
     pass
 
 
-HasExtendedDebugLoggerMeta = HasLogger.replace_logger_class(ExtendedDebugLogger)
+HasExtendedDebugLoggerMeta = HasLoggerMeta.replace_logger_class(ExtendedDebugLogger)
 
 
 class _BaseHasExtendedDebugLogger(metaclass=HasExtendedDebugLoggerMeta):  # type: ignore

--- a/tests/logging-utils/test_compat_with_abc_ABC.py
+++ b/tests/logging-utils/test_compat_with_abc_ABC.py
@@ -1,0 +1,23 @@
+from abc import ABCMeta, abstractmethod
+import logging
+
+import pytest
+
+from eth_utils import HasLoggerMeta
+
+
+class HasLoggerCompatWithABC(metaclass=HasLoggerMeta.meta_compat(ABCMeta)):
+    @abstractmethod
+    def something(self):
+        ...
+
+
+def test_has_logger_compat_with_abc_ABC():
+    assert hasattr(HasLoggerCompatWithABC, "logger")
+    assert isinstance(HasLoggerCompatWithABC.logger, logging.Logger)
+    assert HasLoggerCompatWithABC.logger.name.endswith("HasLoggerCompatWithABC")
+
+
+def test_abc_still_enforces_abstract_methods():
+    with pytest.raises(TypeError):
+        HasLoggerCompatWithABC()

--- a/tests/logging-utils/test_compat_with_typing_Generic.py
+++ b/tests/logging-utils/test_compat_with_typing_Generic.py
@@ -1,0 +1,16 @@
+import logging
+from typing import GenericMeta, TypeVar
+
+from eth_utils import HasLoggerMeta
+
+T = TypeVar("T")
+
+
+class HasLoggerCompatWithGeneric(metaclass=HasLoggerMeta.meta_compat(GenericMeta)):
+    ...
+
+
+def test_has_logger_compat_with_typing_Generic():
+    assert hasattr(HasLoggerCompatWithGeneric, "logger")
+    assert isinstance(HasLoggerCompatWithGeneric.logger, logging.Logger)
+    assert HasLoggerCompatWithGeneric.logger.name.endswith("HasLoggerCompatWithGeneric")

--- a/tests/logging-utils/test_has_logger_metaclass.py
+++ b/tests/logging-utils/test_has_logger_metaclass.py
@@ -1,6 +1,11 @@
 import logging
 
-from eth_utils.logging import ExtendedDebugLogger, HasExtendedDebugLogger, HasLogger
+from eth_utils.logging import (
+    ExtendedDebugLogger,
+    HasExtendedDebugLogger,
+    HasLogger,
+    HasLoggerMeta,
+)
 
 
 class DefinedAtModule(HasLogger):
@@ -77,7 +82,7 @@ class FancyLogger(logging.Logger):
 
 
 def test_can_override_logging_class():
-    class HasFancyLogger(HasLogger[FancyLogger]):
+    class HasFancyLogger(metaclass=HasLoggerMeta.replace_logger_class(FancyLogger)):
         pass
 
     assert hasattr(HasFancyLogger, "logger")

--- a/tests/type-checks/mypy_typing_of_has_logger.py
+++ b/tests/type-checks/mypy_typing_of_has_logger.py
@@ -1,6 +1,12 @@
 import logging
+from typing import Generic, GenericMeta, TypeVar
 
-from eth_utils import ExtendedDebugLogger, HasExtendedDebugLogger, HasLogger
+from eth_utils import (
+    ExtendedDebugLogger,
+    HasExtendedDebugLogger,
+    HasLogger,
+    HasLoggerMeta,
+)
 
 
 def verify_has_logger_type() -> logging.Logger:
@@ -9,3 +15,32 @@ def verify_has_logger_type() -> logging.Logger:
 
 def verify_has_extended_debug_logger_type() -> ExtendedDebugLogger:
     return HasExtendedDebugLogger.logger
+
+
+GenericWithLoggerMeta = HasLoggerMeta.meta_compat(GenericMeta)
+
+
+# mypy doesn't recognize this as a valid metaclass but it still functions
+# properly
+class GenericWithLogger(Generic, metaclass=GenericWithLoggerMeta):  # type: ignore
+    pass
+
+
+T = TypeVar("T")
+
+
+# mypy gets confused about the actual provision of the types for the generics
+# but the actual type checking mechanism below works.
+class VerifyGenericWithLoggerTyping(GenericWithLogger[T]):  # type: ignore
+    @classmethod
+    def return_T(cls, value: T) -> T:
+        return value
+
+
+class VerifyGenericWithLoggerTypingInteger(VerifyGenericWithLoggerTyping[int]):
+    pass
+
+
+int_value: int
+
+int_value = VerifyGenericWithLoggerTypingInteger.return_T(1234)

--- a/tests/type-checks/mypy_typing_of_has_logger.py
+++ b/tests/type-checks/mypy_typing_of_has_logger.py
@@ -44,3 +44,8 @@ class VerifyGenericWithLoggerTypingInteger(VerifyGenericWithLoggerTyping[int]):
 int_value: int
 
 int_value = VerifyGenericWithLoggerTypingInteger.return_T(1234)
+
+# mypy should be angry about passing a non-integer into this function.  We test
+# this by using an ignore comment relying on our type checking settings to warn
+# on un-used ignore statements
+VerifyGenericWithLoggerTypingInteger.return_T("not-an-integer")  # type: ignore


### PR DESCRIPTION
### What was wrong?

The utils committed previously in #158 didn't play well with other metaclasses.

### How was it fixed?

1. Expose the metaclasses as public APIs
2. Add a convenience API onto the `HasLoggerMeta` for combining it with another Metaclass to make python happy.
3. Add tests that ensure that usage of `HasLoggerMeta` in conjunction with `abc.ABCMeta` or `typing.GenericMeta` work as expected.

#### Cute Animal Picture

![17-05-03 Sport (3)C1000CM](https://user-images.githubusercontent.com/824194/62482129-96297e80-b771-11e9-8c85-a819993849e0.JPG)

