### PR TITLE
caching of checks for whether to log at DEBUG2 levels

### DIFF
--- a/tests/logging-utils/test_DEBUG2_logging.py
+++ b/tests/logging-utils/test_DEBUG2_logging.py
@@ -35,7 +35,9 @@ def test_extended_debug_logger(caplog, DEBUG2_installed):
     assert record.message == "message 1"
 
 
-def test_caching_of_debug2_when_disabled(DEBUG2_installed):
+def test_caching_of_debug2_when_disabled(caplog, DEBUG2_installed):
+    caplog.set_level(DEBUG2_LEVEL_NUM, "testing")
+
     # we need a unique logger because loggers are cached
     logger = logging.getLogger("testing-{}".format(uuid.uuid4()))
 
@@ -46,17 +48,24 @@ def test_caching_of_debug2_when_disabled(DEBUG2_installed):
     # cached property should have inserted it into the dict
     assert 'show_debug2' in logger.__dict__
 
+    # sanity pre-check
+    assert len(caplog.records) == 0
+
     assert 'debug2' not in logger.__dict__
     assert logger.debug2('this should actually call the function') is None
     assert 'debug2' in logger.__dict__
     assert logger.debug2('should not do anything but hit the lambda') is None
+
+    assert len(caplog.records) == 0
 
     # now see that it always returns the value from `__dict__`
     logger.__dict__['show_debug2'] = 100
     assert logger.show_debug2 == 100
 
 
-def test_caching_of_debug2_when_enabled(DEBUG2_installed):
+def test_caching_of_debug2_when_enabled(caplog, DEBUG2_installed):
+    caplog.set_level(DEBUG2_LEVEL_NUM, "testing")
+
     # we need a unique logger because loggers are cached
     logger = logging.getLogger("testing-{}".format(uuid.uuid4()))
 
@@ -69,10 +78,15 @@ def test_caching_of_debug2_when_enabled(DEBUG2_installed):
     # cached property should have inserted it into the dict
     assert 'show_debug2' in logger.__dict__
 
+    # sanity pre-check
+    assert len(caplog.records) == 0
+
     assert 'debug2' not in logger.__dict__
     assert logger.debug2('this should actually call the function') is None
     assert 'debug2' not in logger.__dict__
     assert logger.debug2('this should still call the function') is None
+
+    assert len(caplog.records) == 2
 
     # now see that it always returns the value from `__dict__`
     logger.__dict__['show_debug2'] = 100

--- a/tests/logging-utils/test_DEBUG2_logging.py
+++ b/tests/logging-utils/test_DEBUG2_logging.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 import pytest
 
@@ -7,7 +8,7 @@ from eth_utils.logging import DEBUG2_LEVEL_NUM
 
 
 @pytest.fixture
-def DEBUG2_enabled():
+def DEBUG2_installed():
     # caplog only works on loggers retrieved from `logging.getLogger` so we
     # have to use that mechanism to instantiate our logger.
     original_logger = logging.getLoggerClass()
@@ -19,7 +20,7 @@ def DEBUG2_enabled():
         logging.setLoggerClass(original_logger)
 
 
-def test_extended_debug_logger(caplog, DEBUG2_enabled):
+def test_extended_debug_logger(caplog, DEBUG2_installed):
     caplog.set_level(DEBUG2_LEVEL_NUM, "testing")
 
     logger = logging.getLogger("testing")
@@ -32,3 +33,47 @@ def test_extended_debug_logger(caplog, DEBUG2_enabled):
     assert record.levelno == 8
     assert record.args == (1,)
     assert record.message == "message 1"
+
+
+def test_caching_of_debug2_when_disabled(DEBUG2_installed):
+    # we need a unique logger because loggers are cached
+    logger = logging.getLogger("testing-{}".format(uuid.uuid4()))
+
+    assert logger.isEnabledFor(DEBUG2_LEVEL_NUM) is False
+
+    assert 'show_debug2' not in logger.__dict__
+    assert logger.show_debug2 is False
+    # cached property should have inserted it into the dict
+    assert 'show_debug2' in logger.__dict__
+
+    assert 'debug2' not in logger.__dict__
+    assert logger.debug2('this should actually call the function') is None
+    assert 'debug2' in logger.__dict__
+    assert logger.debug2('should not do anything but hit the lambda') is None
+
+    # now see that it always returns the value from `__dict__`
+    logger.__dict__['show_debug2'] = 100
+    assert logger.show_debug2 == 100
+
+
+def test_caching_of_debug2_when_enabled(DEBUG2_installed):
+    # we need a unique logger because loggers are cached
+    logger = logging.getLogger("testing-{}".format(uuid.uuid4()))
+
+    assert logger.isEnabledFor(DEBUG2_LEVEL_NUM) is False
+    logger.setLevel(DEBUG2_LEVEL_NUM)
+    assert logger.isEnabledFor(DEBUG2_LEVEL_NUM) is True
+
+    assert 'show_debug2' not in logger.__dict__
+    assert logger.show_debug2 is True
+    # cached property should have inserted it into the dict
+    assert 'show_debug2' in logger.__dict__
+
+    assert 'debug2' not in logger.__dict__
+    assert logger.debug2('this should actually call the function') is None
+    assert 'debug2' not in logger.__dict__
+    assert logger.debug2('this should still call the function') is None
+
+    # now see that it always returns the value from `__dict__`
+    logger.__dict__['show_debug2'] = 100
+    assert logger.show_debug2 == 100


### PR DESCRIPTION
### What was wrong?

`DEBUG2` implements some performance issues with the overhead of determining if logs should be shown for a given level each time the function is called.

### How was it fixed?

We fully cache whether the log level is enabled as well as turning the `ExtendedDebugLogger.debug2` function into a noop in the event that `DEBUG2` is disabled.


#### Cute Animal Picture

![13-07-13 Red Sport (11)C750R](https://user-images.githubusercontent.com/824194/62494908-c3862480-b791-11e9-9995-c010b958fd41.jpg)

