### PR TITLE
add get_logger and get_extended_debug_logger

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1302,6 +1302,40 @@ ellipsis, only showing the first and last four characters of the hash.
 Logging Utils
 ~~~~~~~~~~~~~~
 
+
+``get_logger(string, [, logger_class]) -> logger``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is similar to the standard library ``logging.getLogger`` however, the
+logger it returns will be an instance of the provided ``logger_class``.  If
+``logger_class`` is not provided this returns an instance of whatever the
+current default logger class is set on the ``logging``.
+
+
+.. doctest::
+
+    >>> import logging
+    >>> from eth_utils import get_logger
+    >>> logger = get_logger('my_application')
+    >>> assert logger.name == 'my_application'
+    >>> assert isinstance(logger, logging.getLoggerClass())
+
+
+``get_extended_debug_logger(string) -> ExtendedDebugLogger``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Like ``get_logger`` except that it always returns an instance of ``ExtendedDebugLogger``
+
+
+.. doctest::
+
+    >>> from eth_utils import get_extended_debug_logger, ExtendedDebugLogger
+    >>> logger = get_extended_debug_logger('my_application')
+    >>> assert logger.name == 'my_application'
+    >>> assert isinstance(logger, ExtendedDebugLogger), type(logger)
+
+
+
 ``class HasLogger``
 ^^^^^^^^^^^^^^^^^^^
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -72,6 +72,8 @@ from .logging import (  # noqa: F401
     HasExtendedDebugLoggerMeta,
     HasLogger,
     HasLoggerMeta,
+    get_extended_debug_logger,
+    get_logger,
     setup_DEBUG2_logging,
 )
 from .module_loading import import_string  # noqa: F401

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -28,6 +28,8 @@ from eth_utils import (
     from_wei,
     function_abi_to_4byte_selector,
     function_signature_to_4byte_selector,
+    get_extended_debug_logger,
+    get_logger,
     hexstr_if_str,
     humanize_hash,
     humanize_ipfs_uri,
@@ -86,6 +88,7 @@ apply_formatters_to_sequence = curry(apply_formatters_to_sequence)
 apply_key_map = curry(apply_key_map)
 apply_one_of_formatters = curry(apply_one_of_formatters)
 from_wei = curry(from_wei)
+get_logger = curry(get_logger)
 hexstr_if_str = curry(hexstr_if_str)
 is_same_address = curry(is_same_address)
 text_if_str = curry(text_if_str)

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -68,8 +68,14 @@ def get_logger(name: str, logger_class: Type[TLogger] = None) -> TLogger:
         return logging.getLogger(name)
     else:
         with _use_logger_class(logger_class):
+            # The logging module caches logger instances.  The following code
+            # ensures that if there is a cached instance that we don't
+            # accidentally return the incorrect logger type because the logging
+            # module does not *update* the cached instance in the event that
+            # the global logging class changes.
             if name in logging.Logger.manager.loggerDict:
-                del logging.Logger.manager.loggerDict[name]
+                if type(logging.Logger.manager.loggerDict[name]) is not logger_class:
+                    del logging.Logger.manager.loggerDict[name]
             return logging.getLogger(name)
 
 

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -51,13 +51,30 @@ def setup_DEBUG2_logging() -> None:
 
 
 @contextlib.contextmanager
-def _use_logger_class(logger_cls: Type[logging.Logger]) -> Iterator:
-    original_logger_cls = logging.getLoggerClass()
-    logging.setLoggerClass(logger_cls)
+def _use_logger_class(logger_class: Type[logging.Logger]) -> Iterator:
+    original_logger_class = logging.getLoggerClass()
+    logging.setLoggerClass(logger_class)
     try:
         yield
     finally:
-        logging.setLoggerClass(original_logger_cls)
+        logging.setLoggerClass(original_logger_class)
+
+
+TLogger = TypeVar("TLogger", bound=logging.Logger)
+
+
+def get_logger(name: str, logger_class: Type[TLogger] = None) -> TLogger:
+    if logger_class is None:
+        return logging.getLogger(name)
+    else:
+        with _use_logger_class(logger_class):
+            if name in logging.Logger.manager.loggerDict:
+                del logging.Logger.manager.loggerDict[name]
+            return logging.getLogger(name)
+
+
+def get_extended_debug_logger(name: str) -> ExtendedDebugLogger:
+    return get_logger(name, ExtendedDebugLogger)
 
 
 THasLoggerMeta = TypeVar("THasLoggerMeta", bound="HasLoggerMeta")

--- a/newsfragments/170.feature.rst
+++ b/newsfragments/170.feature.rst
@@ -1,0 +1,1 @@
+Add ``get_logger`` and ``get_extended_debug_logger`` utils

--- a/tests/logging-utils/test_get_logger.py
+++ b/tests/logging-utils/test_get_logger.py
@@ -4,6 +4,10 @@ import uuid
 from eth_utils.logging import ExtendedDebugLogger, get_extended_debug_logger, get_logger
 
 
+class CustomLogger(logging.Logger):
+    pass
+
+
 def test_get_logger_with_no_class():
     path = "testing.{0}".format(uuid.uuid4())
     logger = get_logger(path)
@@ -18,10 +22,10 @@ def test_get_logger_with_default_class():
     assert logger.name == path
 
 
-def test_get_logger_with_ExtendedDebugLogger():
+def test_get_logger_with_CustomLogger():
     path = "testing.{0}".format(uuid.uuid4())
-    logger = get_logger(path, ExtendedDebugLogger)
-    assert isinstance(logger, ExtendedDebugLogger)
+    logger = get_logger(path, CustomLogger)
+    assert isinstance(logger, CustomLogger)
     assert logger.name == path
 
 
@@ -41,3 +45,13 @@ def test_get_extended_debug_logger_if_other_logger_in_cache():
     extended_logger = get_extended_debug_logger(path)
     assert isinstance(extended_logger, ExtendedDebugLogger)
     assert extended_logger.name == path
+
+
+def test_get_logger_preserves_logging_module_config():
+    assert logging.getLoggerClass() is logging.Logger
+
+    path = "testing.{0}".format(uuid.uuid4())
+    logger = get_logger(path, CustomLogger)
+    assert isinstance(logger, CustomLogger)
+
+    assert logging.getLoggerClass() is logging.Logger

--- a/tests/logging-utils/test_get_logger.py
+++ b/tests/logging-utils/test_get_logger.py
@@ -1,0 +1,43 @@
+import logging
+import uuid
+
+from eth_utils.logging import ExtendedDebugLogger, get_extended_debug_logger, get_logger
+
+
+def test_get_logger_with_no_class():
+    path = "testing.{0}".format(uuid.uuid4())
+    logger = get_logger(path)
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == path
+
+
+def test_get_logger_with_default_class():
+    path = "testing.{0}".format(uuid.uuid4())
+    logger = get_logger(path, logging.Logger)
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == path
+
+
+def test_get_logger_with_ExtendedDebugLogger():
+    path = "testing.{0}".format(uuid.uuid4())
+    logger = get_logger(path, ExtendedDebugLogger)
+    assert isinstance(logger, ExtendedDebugLogger)
+    assert logger.name == path
+
+
+def test_get_extended_debug_logger():
+    path = "testing.{0}".format(uuid.uuid4())
+    logger = get_extended_debug_logger(path)
+    assert isinstance(logger, ExtendedDebugLogger)
+    assert logger.name == path
+
+
+def test_get_extended_debug_logger_if_other_logger_in_cache():
+    path = "testing.{0}".format(uuid.uuid4())
+    normal_logger = get_logger(path)
+    assert not isinstance(normal_logger, ExtendedDebugLogger)
+    assert normal_logger.name == path
+
+    extended_logger = get_extended_debug_logger(path)
+    assert isinstance(extended_logger, ExtendedDebugLogger)
+    assert extended_logger.name == path


### PR DESCRIPTION
### What was wrong?

The metaclass approach to installing loggers is nice but it turns out it's really hard to use because it doesn't play well with other metaclasses and you have to do a [a lot of really gross boilerplate](https://github.com/ethereum/py-evm/blob/8a1052f7bc04b744d20ffcb3f947bc5857c1e16c/eth/abc_compat.py) to make it work.

### How was it fixed?

This PR exposes two new utilties, `get_logger` and `get_extended_debug_logger`.

`get_logger` is like `logging.getLogger` but it takes an additional `logger_class` which dictates the type of logger that should be returned.

`get_extended_debug_logger` is just an implementation of `get_logger` that always returns an `ExtendedDebugLogger`.


#### Cute Animal Picture

![3b825e5d29c1d4bfb4570da4f689fede--pet-halloween-costumes-pet-costumes](https://user-images.githubusercontent.com/824194/63960606-25157800-ca4c-11e9-8faa-0ef011d306f5.jpg)

