### PR TITLE
Expose the DEBUG2 logging level variable as top level import.

### DIFF
--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -66,6 +66,7 @@ from .hexadecimal import (  # noqa: F401
 )
 from .humanize import humanize_hash, humanize_ipfs_uri, humanize_seconds  # noqa: F401
 from .logging import (  # noqa: F401
+    DEBUG2_LEVEL_NUM,
     ExtendedDebugLogger,
     HasExtendedDebugLogger,
     HasExtendedDebugLoggerMeta,

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -26,6 +26,7 @@ class ExtendedDebugLogger(logging.Logger):
     """
     Logging class that can be used for lower level debug logging.
     """
+
     @cached_show_debug2_property
     def show_debug2(self) -> bool:
         return self.isEnabledFor(DEBUG2_LEVEL_NUM)
@@ -37,7 +38,7 @@ class ExtendedDebugLogger(logging.Logger):
             # When we find that `DEBUG2` isn't enabled we completely replace
             # the `debug2` function in this instance of the logger with a noop
             # lambda to further speed up
-            self.__dict__['debug2'] = lambda message, *args, **kwargs: None
+            self.__dict__["debug2"] = lambda message, *args, **kwargs: None
 
 
 def setup_DEBUG2_logging() -> None:

--- a/tests/logging-utils/test_DEBUG2_logging.py
+++ b/tests/logging-utils/test_DEBUG2_logging.py
@@ -43,23 +43,23 @@ def test_caching_of_debug2_when_disabled(caplog, DEBUG2_installed):
 
     assert logger.isEnabledFor(DEBUG2_LEVEL_NUM) is False
 
-    assert 'show_debug2' not in logger.__dict__
+    assert "show_debug2" not in logger.__dict__
     assert logger.show_debug2 is False
     # cached property should have inserted it into the dict
-    assert 'show_debug2' in logger.__dict__
+    assert "show_debug2" in logger.__dict__
 
     # sanity pre-check
     assert len(caplog.records) == 0
 
-    assert 'debug2' not in logger.__dict__
-    assert logger.debug2('this should actually call the function') is None
-    assert 'debug2' in logger.__dict__
-    assert logger.debug2('should not do anything but hit the lambda') is None
+    assert "debug2" not in logger.__dict__
+    assert logger.debug2("this should actually call the function") is None
+    assert "debug2" in logger.__dict__
+    assert logger.debug2("should not do anything but hit the lambda") is None
 
     assert len(caplog.records) == 0
 
     # now see that it always returns the value from `__dict__`
-    logger.__dict__['show_debug2'] = 100
+    logger.__dict__["show_debug2"] = 100
     assert logger.show_debug2 == 100
 
 
@@ -73,21 +73,21 @@ def test_caching_of_debug2_when_enabled(caplog, DEBUG2_installed):
     logger.setLevel(DEBUG2_LEVEL_NUM)
     assert logger.isEnabledFor(DEBUG2_LEVEL_NUM) is True
 
-    assert 'show_debug2' not in logger.__dict__
+    assert "show_debug2" not in logger.__dict__
     assert logger.show_debug2 is True
     # cached property should have inserted it into the dict
-    assert 'show_debug2' in logger.__dict__
+    assert "show_debug2" in logger.__dict__
 
     # sanity pre-check
     assert len(caplog.records) == 0
 
-    assert 'debug2' not in logger.__dict__
-    assert logger.debug2('this should actually call the function') is None
-    assert 'debug2' not in logger.__dict__
-    assert logger.debug2('this should still call the function') is None
+    assert "debug2" not in logger.__dict__
+    assert logger.debug2("this should actually call the function") is None
+    assert "debug2" not in logger.__dict__
+    assert logger.debug2("this should still call the function") is None
 
     assert len(caplog.records) == 2
 
     # now see that it always returns the value from `__dict__`
-    logger.__dict__['show_debug2'] = 100
+    logger.__dict__["show_debug2"] = 100
     assert logger.show_debug2 == 100

--- a/tests/logging-utils/test_compat_with_typing_Generic.py
+++ b/tests/logging-utils/test_compat_with_typing_Generic.py
@@ -6,7 +6,9 @@ import pytest
 from eth_utils import HasLoggerMeta
 
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 7), reason="GenericMeta not present in Python 3.7+")
+@pytest.mark.skipif(
+    sys.version_info[:2] >= (3, 7), reason="GenericMeta not present in Python 3.7+"
+)
 def test_has_logger_compat_with_typing_Generic():
     from typing import GenericMeta
 


### PR DESCRIPTION
### What was wrong?

The logging level for `DEBUG2` was not exposed in the primary public API.

### How was it fixed?

Added it to the main `eth_utils` top level import API.

#### Cute Animal Picture


![Animals-in-Costumes-112790](https://user-images.githubusercontent.com/824194/63960782-7b82b680-ca4c-11e9-848a-e8dd896cc0bb.jpg)
