### PR TITLE
Add python3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: lint-py37
+  lint-py38:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: lint-py38
   py35:
     <<: *common
     docker:
@@ -79,6 +85,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37
+  py38:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38
   py36-typing1:
     <<: *common
     docker:
@@ -98,8 +110,10 @@ workflows:
       - docs
       - lint-py36
       - lint-py37
+      - lint-py38
       - py35
       - py36
       - py37
+      - py38
       - py36-typing1
       - pypy3

--- a/newsfragments/174.feature.rst
+++ b/newsfragments/174.feature.rst
@@ -1,0 +1,1 @@
+Add support for python3.8

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         'pytest>=3.4.1,<4.0.0',
     ],
     'test': [
-        'hypothesis>=3.4.2,<4.0.0',
+        'hypothesis>=4.43.0,<5.0.0',
         'pytest>=3.4.1,<4.0.0',
         'pytest-pythonpath>=0.3,<1.0',
     ],
@@ -55,7 +55,7 @@ setup(
         "eth-hash>=0.1.0,<1.0.0",
         "eth-typing>=1.0.0,<3.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",
-        "cytoolz>=0.8.2,<1.0.0;implementation_name=='cpython'",
+        "cytoolz>=0.10.1,<1.0.0;implementation_name=='cpython'",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5,!=3.5.2,<4',
@@ -74,6 +74,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{35,36,37,py3},
+    py{35,36,37,38,py3},
     py36-typing1,
-    lint-py{36,37},
+    lint-py{36,37,38},
     docs
 
 [isort]
@@ -36,6 +36,7 @@ basepython=
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     mypy: mypy
     pypy3: pypy3
 whitelist_externals=make


### PR DESCRIPTION
### What was wrong?

python3.8 support was missing.

### How was it fixed?

Added support for python3.8 by updating the version of libraries that were breaking with python3.8.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/ku90m5ll4kw31.jpg)
