### PR TITLE
Update hexstr type hints

### DIFF
--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -5,6 +5,8 @@ import codecs
 import string
 from typing import Any, AnyStr
 
+from eth_typing import HexStr
+
 from .types import is_string, is_text
 
 
@@ -16,7 +18,7 @@ def decode_hex(value: str) -> bytes:
     return codecs.decode(remove_0x_prefix(value), "hex")  # type: ignore
 
 
-def encode_hex(value: AnyStr) -> str:
+def encode_hex(value: AnyStr) -> HexStr:
     if not is_string(value):
         raise TypeError("Value must be an instance of str or unicode")
     binary_hex = codecs.encode(value, "hex")  # type: ignore
@@ -31,13 +33,13 @@ def is_0x_prefixed(value: Any) -> bool:
     return value.startswith("0x") or value.startswith("0X")
 
 
-def remove_0x_prefix(value: str) -> str:
+def remove_0x_prefix(value: HexStr) -> HexStr:
     if is_0x_prefixed(value):
         return value[2:]
     return value
 
 
-def add_0x_prefix(value: str) -> str:
+def add_0x_prefix(value: HexStr) -> HexStr:
     if is_0x_prefixed(value):
         return value
     return "0x" + value

--- a/newsfragments/175.misc.rst
+++ b/newsfragments/175.misc.rst
@@ -1,0 +1,1 @@
+Update type hints in Hexadecimal module.


### PR DESCRIPTION
### What was wrong?
Some functions in the `hexadecimal` module are better suited to using `HexStr` types rather than a simple `str`

### To-Do
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/68658204-4ce98780-0535-11ea-8dc8-508b32bc689e.png)

