### PR TITLE
Update type hint for to_wei [Fixes: #168]

### DIFF
--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -61,7 +61,7 @@ def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
     return result_value
 
 
-def to_wei(number: int, unit: str) -> int:
+def to_wei(number: int, unit: str) -> Union[int, float, str, Decimal]:
     """
     Takes a number of a unit and converts it to wei.
     """

--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -61,7 +61,7 @@ def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
     return result_value
 
 
-def to_wei(number: int, unit: str) -> Union[int, float, str, Decimal]:
+def to_wei(number: int, unit: str) -> Union[int, float, str, decimal.Decimal]:
     """
     Takes a number of a unit and converts it to wei.
     """

--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -61,7 +61,7 @@ def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
     return result_value
 
 
-def to_wei(number: int, unit: str) -> Union[int, float, str, decimal.Decimal]:
+def to_wei(number: Union[int, float, str, decimal.Decimal], unit: str) -> int:
     """
     Takes a number of a unit and converts it to wei.
     """


### PR DESCRIPTION
### What was wrong?
The type hint for `to_wei` only allows ints, but the implementation also accepts floats, strs, and Decimals.


### How was it fixed?

Updated type hint for `float`, `str` and `Decimal` as requested in issue #168

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
