### PR TITLE
Add type overload to curried fn apply_formatter_if

### DIFF
--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Generator, List, Tuple
+from typing import Any, Callable, Dict, Generator, List, Tuple, overload
 import warnings
 
 from .decorators import return_arg_type
@@ -65,8 +65,22 @@ def apply_formatters_to_sequence(
             yield formatter(item)
 
 
+@overload
 def apply_formatter_if(
-    condition: Callable[..., Any], formatter: Callable[..., Any], value: Any
+    condition: Callable[..., bool]
+) -> Callable[[Callable[..., Any]], Callable[[Any], Any]]:
+    pass
+
+
+@overload
+def apply_formatter_if(
+    condition: Callable[..., bool], formatter: Callable[..., Any]
+) -> Callable[[Any], Any]:
+    pass
+
+
+def apply_formatter_if(
+    condition: Callable[..., bool], formatter: Callable[..., Any], value: Any
 ) -> Any:
     if condition(value):
         return formatter(value)

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Generator, List, Tuple, overload
+from typing import Any, Callable, Dict, Generator, List, Tuple
 import warnings
 
 from .decorators import return_arg_type
@@ -63,20 +63,6 @@ def apply_formatters_to_sequence(
     else:
         for formatter, item in zip(formatters, sequence):
             yield formatter(item)
-
-
-@overload
-def apply_formatter_if(
-    condition: Callable[..., bool]
-) -> Callable[[Callable[..., Any]], Callable[[Any], Any]]:
-    pass
-
-
-@overload
-def apply_formatter_if(
-    condition: Callable[..., bool], formatter: Callable[..., Any]
-) -> Callable[[Any], Any]:
-    pass
 
 
 def apply_formatter_if(

--- a/eth_utils/curried/__init__.pyi
+++ b/eth_utils/curried/__init__.pyi
@@ -1,0 +1,122 @@
+from typing import (
+    Any,
+    Callable,
+    Tuple,
+    overload,
+)
+
+from eth_utils.curried import (
+    ExtendedDebugLogger,
+    HasExtendedDebugLogger,
+    HasExtendedDebugLoggerMeta,
+    HasLogger,
+    HasLoggerMeta,
+    ValidationError,
+    add_0x_prefix,
+    apply_formatter_at_index,
+    apply_formatter_if,
+    apply_formatter_to_array,
+    apply_formatters_to_dict,
+    apply_formatters_to_sequence,
+    apply_key_map,
+    apply_one_of_formatters,
+    apply_to_return_value,
+    big_endian_to_int,
+    clamp,
+    combine_argument_formatters,
+    combomethod,
+    decode_hex,
+    denoms,
+    encode_hex,
+    event_abi_to_log_topic,
+    event_signature_to_log_topic,
+    flatten_return,
+    from_wei,
+    function_abi_to_4byte_selector,
+    function_signature_to_4byte_selector,
+    get_extended_debug_logger,
+    get_logger,
+    hexstr_if_str,
+    humanize_hash,
+    humanize_ipfs_uri,
+    humanize_seconds,
+    import_string,
+    int_to_big_endian,
+    is_0x_prefixed,
+    is_address,
+    is_binary_address,
+    is_boolean,
+    is_bytes,
+    is_canonical_address,
+    is_checksum_address,
+    is_checksum_formatted_address,
+    is_dict,
+    is_hex,
+    is_hex_address,
+    is_integer,
+    is_list,
+    is_list_like,
+    is_normalized_address,
+    is_null,
+    is_number,
+    is_same_address,
+    is_string,
+    is_text,
+    is_tuple,
+    keccak,
+    remove_0x_prefix,
+    replace_exceptions,
+    reversed_return,
+    setup_DEBUG2_logging,
+    sort_return,
+    text_if_str,
+    to_bytes,
+    to_canonical_address,
+    to_checksum_address,
+    to_dict,
+    to_hex,
+    to_int,
+    to_list,
+    to_normalized_address,
+    to_ordered_dict,
+    to_set,
+    to_text,
+    to_tuple,
+    to_wei,
+)
+
+
+@overload
+def apply_formatter_if(
+    condition: Callable[..., bool]
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ...
+
+
+@overload
+def apply_formatter_if(
+    condition: Callable[..., bool], formatter: Callable[..., Any]
+) -> Callable[..., Any]:
+    ...
+
+
+@overload
+def apply_formatter_if(
+    condition: Callable[..., bool], formatter: Callable[..., Any], value: Any
+) -> Any:
+    ...
+
+
+@overload
+def apply_one_of_formatters(
+    formatter_condition_pairs: Tuple[Tuple[Callable[..., bool], Callable[..., Any]], ...]
+) -> Callable[..., Any]:
+    ...
+
+
+@overload
+def apply_one_of_formatters(
+    formatter_condition_pairs: Tuple[Tuple[Callable[..., bool], Callable[..., Any]], ...],
+    value: Any,
+) -> Any:
+    ...

--- a/eth_utils/curried/__init__.pyi
+++ b/eth_utils/curried/__init__.pyi
@@ -1,7 +1,10 @@
 from typing import (
     Any,
     Callable,
+    Sequence,
     Tuple,
+    TypeVar,
+    Union,
     overload,
 )
 
@@ -85,38 +88,41 @@ from eth_utils.curried import (
     to_wei,
 )
 
+TReturn = TypeVar("TReturn")
+TValue = TypeVar("TValue")
+
 
 @overload
 def apply_formatter_if(
     condition: Callable[..., bool]
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[[Callable[..., TReturn]], Callable[[TValue], Union[TReturn, TValue]]]:
     ...
 
 
 @overload
 def apply_formatter_if(
-    condition: Callable[..., bool], formatter: Callable[..., Any]
-) -> Callable[..., Any]:
+    condition: Callable[..., bool], formatter: Callable[..., TReturn]
+) -> Callable[[TValue], Union[TReturn, TValue]]:
     ...
 
 
 @overload
 def apply_formatter_if(
-    condition: Callable[..., bool], formatter: Callable[..., Any], value: Any
-) -> Any:
+    condition: Callable[..., bool], formatter: Callable[..., TReturn], value: TValue
+) -> Union[TReturn, TValue]:
     ...
 
 
 @overload
 def apply_one_of_formatters(
-    formatter_condition_pairs: Tuple[Tuple[Callable[..., bool], Callable[..., Any]], ...]
-) -> Callable[..., Any]:
+    formatter_condition_pairs: Sequence[Tuple[Callable[..., bool], Callable[..., TReturn]], ...]
+) -> Callable[[TValue], TReturn]:
     ...
 
 
 @overload
 def apply_one_of_formatters(
-    formatter_condition_pairs: Tuple[Tuple[Callable[..., bool], Callable[..., Any]], ...],
-    value: Any,
-) -> Any:
+    formatter_condition_pairs: Sequence[Tuple[Callable[..., bool], Callable[..., TReturn]], ...],
+    value: TValue,
+) -> TReturn:
     ...

--- a/newsfragments/180.misc.rst
+++ b/newsfragments/180.misc.rst
@@ -1,1 +1,1 @@
-Overload apply_formatter_if types to allow for curried use.
+Add stub file to allow for typing of curried fns.

--- a/newsfragments/180.misc.rst
+++ b/newsfragments/180.misc.rst
@@ -1,0 +1,1 @@
+Overload apply_formatter_if types to allow for curried use.

--- a/tests/type-checks/mypy_typing_of_curried_utils.py
+++ b/tests/type-checks/mypy_typing_of_curried_utils.py
@@ -1,0 +1,33 @@
+from typing import (
+    Any,
+    List,
+)
+from eth_utils.curried import (
+    apply_formatter_if,
+    apply_one_of_formatters,
+)
+
+from eth_utils import (
+    is_list_like,
+    is_string,
+)
+
+
+def i_put_my_thing_down_flip_it_and_reverse_it(lyric: List[str]) -> str:
+    return "".join(reversed(lyric))
+
+
+CONDITION_FORMATTER_PAIRS = (
+    (is_list_like, tuple),
+    (is_string, i_put_my_thing_down_flip_it_and_reverse_it),
+)
+
+
+apply_formatter_if(is_string)
+apply_formatter_if(is_string, bool)
+apply_formatter_if(is_string, bool, 1)
+
+
+
+apply_one_of_formatters(CONDITION_FORMATTER_PAIRS)
+apply_one_of_formatters(CONDITION_FORMATTER_PAIRS, "my thing")


### PR DESCRIPTION
### What was wrong?
Re: #156 

`apply_formatter_if` is used quite liberally in `web3` and each one requires a `type: ignore`, but not anymore with the overload types implemented.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/70060810-7ef58300-15e3-11ea-87db-3936f414f62a.png)

