### PR TITLE
Add interface files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,7 @@ include VERSION
 include README.md
 include requirements.txt
 
+global-include .pyi
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -11,7 +11,7 @@ class combomethod(object):
     def __init__(self, method: Callable[..., Any]) -> None:
         self.method = method
 
-    def __get__(self, obj: T = None, objtype: Type[T] = None) -> Callable[..., T]:
+    def __get__(self, obj: T = None, objtype: Type[T] = None) -> Callable[..., Any]:
         @functools.wraps(self.method)
         def _wrapper(*args: Any, **kwargs: Any) -> Any:
             if obj is not None:

--- a/newsfragments/181.misc.rst
+++ b/newsfragments/181.misc.rst
@@ -1,0 +1,1 @@
+Add global-include for .pyi files in build manifest.


### PR DESCRIPTION
### What was wrong?
-  `.pyi` files were not being included in the distributions.
- Fix broken `combomethod` type hints.

### How was it fixed?
Added a `global-include` for `.pyi` files in `MANIFEST.in`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/70135042-8cfddf00-1689-11ea-9d2e-1b671017e4d8.png)

