### PR TITLE
Add is_hexstr function

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1244,6 +1244,46 @@ type.
    Traceback (most recent call last):
    TypeError: is_hex requires text typed arguments.
 
+``is_hexstr(value)`` -> bool
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Returns ``True`` if ``value`` is a hexadecimal encoded string of text
+type.
+
+.. note::
+
+    This function differs from ``is_hex(value: Any)`` in that it will return
+    False on all non-text type arguments, while ``is_hex`` will raise a ``TypeError``
+    for all non-text type arguments.
+
+.. doctest::
+
+   >>> from eth_utils import is_hexstr
+   >>> is_hexstr('')
+   False
+   >>> is_hexstr('0x')
+   True
+   >>> is_hexstr('0X')
+   True
+   >>> is_hexstr('1234567890abcdef')
+   True
+   >>> is_hexstr('0x1234567890abcdef')
+   True
+   >>> is_hexstr('0x1234567890ABCDEF')
+   True
+   >>> is_hexstr('0x1234567890AbCdEf')
+   True
+   >>> is_hexstr('12345')  # odd length is ok
+   True
+   >>> is_hexstr('0x12345')  # odd length is ok
+   True
+   >>> is_hexstr('123456__abcdef')  # non hex characters
+   False
+   >>> is_hexstr(b'') # any non-string returns False
+   False
+   >>> is_hex(b'0x') # any non-string returns False
+   False
+
 ``remove_0x_prefix(value: HexStr)`` -> HexStr_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1281,7 +1281,7 @@ type.
    False
    >>> is_hexstr(b'') # any non-string returns False
    False
-   >>> is_hex(b'0x') # any non-string returns False
+   >>> is_hexstr(b'0x') # any non-string returns False
    False
 
 ``remove_0x_prefix(value: HexStr)`` -> HexStr_

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -62,6 +62,7 @@ from .hexadecimal import (  # noqa: F401
     encode_hex,
     is_0x_prefixed,
     is_hex,
+    is_hexstr,
     remove_0x_prefix,
 )
 from .humanize import humanize_hash, humanize_ipfs_uri, humanize_seconds  # noqa: F401

--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -12,8 +12,6 @@ def is_hex_address(value: Any) -> bool:
     """
     Checks if the given string of text type is an address in hexadecimal encoded form.
     """
-    if not is_text(value):
-        return False
     if not is_hexstr(value):
         return False
     else:
@@ -135,8 +133,6 @@ def is_checksum_address(value: Any) -> bool:
 
 
 def is_checksum_formatted_address(value: Any) -> bool:
-    if not is_text(value):
-        return False
 
     if not is_hex_address(value):
         return False

--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -4,7 +4,7 @@ from eth_typing import Address, AnyAddress, ChecksumAddress, HexAddress, HexStr
 
 from .conversions import hexstr_if_str, to_hex
 from .crypto import keccak
-from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hex, remove_0x_prefix
+from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hexstr, remove_0x_prefix
 from .types import is_bytes, is_text
 
 
@@ -14,7 +14,7 @@ def is_hex_address(value: Any) -> bool:
     """
     if not is_text(value):
         return False
-    elif not is_hex(value):
+    if not is_hexstr(value):
         return False
     else:
         unprefixed = remove_0x_prefix(value)

--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -4,7 +4,7 @@ from eth_typing import HexStr, Primitives
 
 from .decorators import validate_conversion_arguments
 from .encoding import big_endian_to_int, int_to_big_endian
-from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hex, remove_0x_prefix
+from .hexadecimal import add_0x_prefix, decode_hex, encode_hex, is_hexstr, remove_0x_prefix
 from .types import is_boolean, is_integer, is_string
 
 T = TypeVar("T")
@@ -146,7 +146,7 @@ def hexstr_if_str(
     :param hexstr_or_primitive bytes, str, int: value to convert
     """
     if isinstance(hexstr_or_primitive, str):
-        if remove_0x_prefix(HexStr(hexstr_or_primitive)) and not is_hex(
+        if remove_0x_prefix(HexStr(hexstr_or_primitive)) and not is_hexstr(
             hexstr_or_primitive
         ):
             raise ValueError(

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -46,6 +46,7 @@ from eth_utils import (
     is_checksum_formatted_address,
     is_dict,
     is_hex,
+    is_hexstr,
     is_hex_address,
     is_integer,
     is_list,

--- a/eth_utils/curried/__init__.pyi
+++ b/eth_utils/curried/__init__.pyi
@@ -55,6 +55,7 @@ from eth_utils.curried import (
     is_checksum_formatted_address,
     is_dict,
     is_hex,
+    is_hexstr,
     is_hex_address,
     is_integer,
     is_list,

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -73,12 +73,6 @@ def is_hexstr(value: Any) -> bool:
 
 
 def is_hex(value: Any) -> bool:
-    warnings.warn(
-        DeprecationWarning(
-            "is_hex(value: Any) has been deprecated and will be removed in a subsequent major version "
-            "release of the eth-utils library. Update your calls to use is_hexstr(value: Any) instead."
-        )
-    )
     if not is_text(value):
         raise TypeError(
             "is_hex requires text typed arguments. Got: {0}".format(repr(value))

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -76,7 +76,7 @@ def is_hex(value: Any) -> bool:
     warnings.warn(
         DeprecationWarning(
             "is_hex(value: Any) has been deprecated and will be removed in a subsequent major version "
-            "release of the eth-utils library. Update your calls to use is_hexstr(Any) instead."
+            "release of the eth-utils library. Update your calls to use is_hexstr(value: Any) instead."
         )
     )
     if not is_text(value):

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -47,7 +47,7 @@ def add_0x_prefix(value: HexStr) -> HexStr:
 
 
 def is_hexstr(value: Any) -> bool:
-    if not isinstance(value, str):
+    if not is_text(value):
         return False
     
     elif value.lower() == "0x":

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -46,6 +46,32 @@ def add_0x_prefix(value: HexStr) -> HexStr:
     return HexStr("0x" + value)
 
 
+def is_hexstr(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    
+    elif value.lower() == "0x":
+        return True
+
+    unprefixed_value = remove_0x_prefix(value)
+    if len(unprefixed_value) % 2 != 0:
+        value_to_decode = "0" + unprefixed_value
+    else:
+        value_to_decode = unprefixed_value
+
+    if any(char not in string.hexdigits for char in value_to_decode):
+        return False
+
+    try:
+        value_as_bytes = codecs.decode(value_to_decode, "hex")  # type: ignore
+    except binascii.Error:
+        return False
+    except TypeError:
+        return False
+    else:
+        return bool(value_as_bytes)
+
+
 def is_hex(value: Any) -> bool:
     warnings.warn(
         DeprecationWarning(

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -3,6 +3,7 @@
 import binascii
 import codecs
 import string
+import warnings
 from typing import Any, AnyStr
 
 from eth_typing import HexStr
@@ -46,6 +47,12 @@ def add_0x_prefix(value: HexStr) -> HexStr:
 
 
 def is_hex(value: Any) -> bool:
+    warnings.warn(
+        DeprecationWarning(
+            "is_hex(value: Any) has been deprecated and will be removed in a subsequent major version "
+            "release of the eth-utils library. Update your calls to use is_hexstr(Any) instead."
+        )
+    )
     if not is_text(value):
         raise TypeError(
             "is_hex requires text typed arguments. Got: {0}".format(repr(value))

--- a/newsfragments/137.feature.rst
+++ b/newsfragments/137.feature.rst
@@ -1,1 +1,1 @@
-Add `ix_hexstr` as preferred method of checking if a given value is a hex string.
+Add `is_hexstr` as preferred method of checking if a given value is a hex string.

--- a/newsfragments/137.feature.rst
+++ b/newsfragments/137.feature.rst
@@ -1,0 +1,1 @@
+Add `ix_hexstr` as preferred method of checking if a given value is a hex string.

--- a/tests/address-utils/test_address_utils.py
+++ b/tests/address-utils/test_address_utils.py
@@ -16,7 +16,7 @@ from eth_utils.address import (
 
 
 @pytest.mark.parametrize(
-    "args,is_any,is_hex,is_binary",
+    "args,is_any,is_hexstr,is_binary",
     (
         # weird values
         (lambda: None, False, False, False),
@@ -102,9 +102,9 @@ from eth_utils.address import (
         ),  # normalized
     ),
 )
-def test_is_address(args, is_any, is_hex, is_binary):
+def test_is_address(args, is_any, is_hexstr, is_binary):
     assert is_address(args) == is_any
-    assert is_hex_address(args) == is_hex
+    assert is_hex_address(args) == is_hexstr
     assert is_binary_address(args) == is_binary
 
 

--- a/tests/hexadecimal-utils/test_is_hex.py
+++ b/tests/hexadecimal-utils/test_is_hex.py
@@ -22,12 +22,18 @@ from eth_utils import is_hex
         ("0\u0080", False),  # triggers different exceptions in py2 and py3
     ),
 )
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_is_hex(value, expected):
     actual = is_hex(value)
     assert actual is expected
 
 
 @pytest.mark.parametrize("value", (b"", 123, {}, lambda: None))
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_is_hex_rejects_non_text_types(value):
     with pytest.raises(TypeError):
         is_hex(value)
+
+def test_is_hex_deprecated():
+    with pytest.deprecated_call():
+        is_hex("")

--- a/tests/hexadecimal-utils/test_is_hex.py
+++ b/tests/hexadecimal-utils/test_is_hex.py
@@ -22,18 +22,12 @@ from eth_utils import is_hex
         ("0\u0080", False),  # triggers different exceptions in py2 and py3
     ),
 )
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_is_hex(value, expected):
     actual = is_hex(value)
     assert actual is expected
 
 
 @pytest.mark.parametrize("value", (b"", 123, {}, lambda: None))
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_is_hex_rejects_non_text_types(value):
     with pytest.raises(TypeError):
         is_hex(value)
-
-def test_is_hex_deprecated():
-    with pytest.deprecated_call():
-        is_hex("")

--- a/tests/hexadecimal-utils/test_is_hexstr.py
+++ b/tests/hexadecimal-utils/test_is_hexstr.py
@@ -15,7 +15,6 @@ from eth_utils import is_hexstr
         ("0xabcdef1234567890", True),
         ("0xABCDEF1234567890", True),
         ("0xAbCdEf1234567890", True),
-        ("0XAbCdEf1234567890", True),
         ("12345", True),  # odd length
         ("0x12345", True),  # odd length
         ("123456xx", False),  # non-hex character

--- a/tests/hexadecimal-utils/test_is_hexstr.py
+++ b/tests/hexadecimal-utils/test_is_hexstr.py
@@ -1,0 +1,31 @@
+import pytest
+
+from eth_utils import is_hexstr
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        ("", False),  # empty string
+        ("0x", True),  # empty string
+        ("0X", True),  # empty string
+        ("abcdef1234567890", True),
+        ("ABCDEF1234567890", True),
+        ("AbCdEf1234567890", True),
+        ("0xabcdef1234567890", True),
+        ("0xABCDEF1234567890", True),
+        ("0xAbCdEf1234567890", True),
+        ("12345", True),  # odd length
+        ("0x12345", True),  # odd length
+        ("123456xx", False),  # non-hex character
+        ("0x123456xx", False),  # non-hex character
+        ("0\u0080", False),  # triggers different exceptions in py2 and py3
+        (1, False),  # int
+        (b"", False),  # bytes
+        ({}, False),  # dicitionary
+        (lambda: None, False)  # lambda function
+    ),
+)
+def test_is_hexstr(value, expected):
+    actual = is_hexstr(value)
+    assert actual is expected

--- a/tests/hexadecimal-utils/test_is_hexstr.py
+++ b/tests/hexadecimal-utils/test_is_hexstr.py
@@ -15,6 +15,7 @@ from eth_utils import is_hexstr
         ("0xabcdef1234567890", True),
         ("0xABCDEF1234567890", True),
         ("0xAbCdEf1234567890", True),
+        ("0XAbCdEf1234567890", True),
         ("12345", True),  # odd length
         ("0x12345", True),  # odd length
         ("123456xx", False),  # non-hex character
@@ -22,7 +23,7 @@ from eth_utils import is_hexstr
         ("0\u0080", False),  # triggers different exceptions in py2 and py3
         (1, False),  # int
         (b"", False),  # bytes
-        ({}, False),  # dicitionary
+        ({}, False),  # dictionary
         (lambda: None, False)  # lambda function
     ),
 )


### PR DESCRIPTION
### What was wrong?
Fixes #137, it was decided that a second function `is_hexstr` should be added that returns False on any
non-string input call to the function.


### How was it fixed?
The specified function was implemented.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ X] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [ X] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/6e/3e/7e/6e3e7ed4169601373bf3f7abcb6d80a4.jpg)
