### PR TITLE
Using regular expression matching in `is_hex()` and `is_hexstr()`

### DIFF
--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -2,6 +2,7 @@
 
 import binascii
 import codecs
+import re
 import string
 import warnings
 from typing import Any, AnyStr
@@ -9,6 +10,9 @@ from typing import Any, AnyStr
 from eth_typing import HexStr
 
 from .types import is_string, is_text
+
+
+_HEX_REGEXP = re.compile("[0-9a-fA-F]*")
 
 
 # Type ignored for `codecs.decode()` due to lack of mypy support for 'hex' encoding
@@ -59,7 +63,7 @@ def is_hexstr(value: Any) -> bool:
     else:
         value_to_decode = unprefixed_value
 
-    if any(char not in string.hexdigits for char in value_to_decode):
+    if not _HEX_REGEXP.fullmatch(value_to_decode):
         return False
 
     try:
@@ -86,7 +90,7 @@ def is_hex(value: Any) -> bool:
     else:
         value_to_decode = unprefixed_value
 
-    if any(char not in string.hexdigits for char in value_to_decode):
+    if not _HEX_REGEXP.fullmatch(value_to_decode):
         return False
 
     try:

--- a/newsfragments/185.feature.rst
+++ b/newsfragments/185.feature.rst
@@ -1,0 +1,1 @@
+Improve performance of `is_hex` and `is_hexstr` by up to 40x


### PR DESCRIPTION
### What was wrong?

I have witnessed more than one `web3.py`-based application which was spending significant share of cpu time (~ 25%-50%) in this specific hex string validation loop.

### How was it fixed?

The new implementation of `is_hex()` and `is_hexstr()` yields significant performance improvement over the previous approach, the new implementation can be about 40x faster according to my tests.

### To-Do

- [X] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![pangolin](https://user-images.githubusercontent.com/10530476/76850092-f1af0500-6846-11ea-9985-72411796a2e8.jpg)

