### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/eth_utils/types.py
+++ b/eth_utils/types.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import numbers
 from typing import Any
 
@@ -29,11 +29,11 @@ def is_boolean(value: Any) -> bool:
 
 
 def is_dict(obj: Any) -> bool:
-    return isinstance(obj, collections.Mapping)
+    return isinstance(obj, collections.abc.Mapping)
 
 
 def is_list_like(obj: Any) -> bool:
-    return not is_string(obj) and isinstance(obj, collections.Sequence)
+    return not is_string(obj) and isinstance(obj, collections.abc.Sequence)
 
 
 def is_list(obj: Any) -> bool:


### PR DESCRIPTION
### What was wrong?

Importing ABC directly from collections was deprecated.

### How was it fixed?

Use collections.abc instead

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()


Fixes #184 