### PR TITLE
Adapts checksum functionality to RSKIP60 and EIP55

### DIFF
--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -107,12 +107,14 @@ def is_same_address(left: AnyAddress, right: AnyAddress) -> bool:
         return to_normalized_address(left) == to_normalized_address(right)
 
 
-def to_checksum_address(value: AnyStr) -> ChecksumAddress:
+def to_checksum_address(value: AnyStr, chain_id: int = 1) -> ChecksumAddress:
     """
     Makes a checksum address given a supported format.
     """
     norm_address = to_normalized_address(value)
-    address_hash = encode_hex(keccak(text=remove_0x_prefix(HexStr(norm_address))))
+    address_hash = encode_hex(
+        keccak(text=remove_0x_prefix(HexStr(norm_address), chain_id))
+    )
 
     checksum_address = add_0x_prefix(
         HexStr(
@@ -122,20 +124,20 @@ def to_checksum_address(value: AnyStr) -> ChecksumAddress:
                     if int(address_hash[i], 16) > 7
                     else norm_address[i]
                 )
-                for i in range(2, 42)
+                for i in range(2, len(norm_address))
             )
         )
     )
     return ChecksumAddress(HexAddress(checksum_address))
 
 
-def is_checksum_address(value: Any) -> bool:
+def is_checksum_address(value: Any, chain_id: int = 1) -> bool:
     if not is_text(value):
         return False
 
     if not is_hex_address(value):
         return False
-    return value == to_checksum_address(value)
+    return value == to_checksum_address(value, chain_id)
 
 
 def is_checksum_formatted_address(value: Any) -> bool:

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -97,5 +97,8 @@ is_same_address = curry(is_same_address)
 text_if_str = curry(text_if_str)
 to_wei = curry(to_wei)
 clamp = curry(clamp)
+is_checksum_address = curry(is_checksum_address)
+remove_0x_prefix = curry(remove_0x_prefix)
+to_checksum_address = curry(to_checksum_address)
 
 del curry

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -40,9 +40,9 @@ def is_0x_prefixed(value: Any) -> bool:
     return value.startswith("0x") or value.startswith("0X")
 
 
-def remove_0x_prefix(value: HexStr) -> HexStr:
+def remove_0x_prefix(value: HexStr, chain_id: int = 1) -> HexStr:
     if is_0x_prefixed(value):
-        return HexStr(value[2:])
+        return HexStr(value[2:] if chain_id == 1 else str(chain_id) + value)
     return value
 
 


### PR DESCRIPTION
### What was wrong?

* Can't allows checksum implementation in any network.
* Can't distinguish between testnets and mainnets.


### How was it fixed?
This PR adapts checksum functionality to [RSKIP-60](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md) compatible with [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md).
The implementation considers sending optional chainId parameter to checksum methods (with chain_id = 1 as default, Ethereum checksum is applied).
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Enhancement


### To-Do
- [x] Clean up commit history

#### Cute Animal Picture

![KakaoTalk_Photo_2020-05-23-23-27-25](https://user-images.githubusercontent.com/11774273/82733305-ecda6600-9d4d-11ea-8df4-1dba941231c2.jpeg)