### PR TITLE
Fix pickling of ExtendedDebugLogger

### DIFF
--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -43,6 +43,11 @@ class ExtendedDebugLogger(logging.Logger):
             # lambda to further speed up
             self.__dict__["debug2"] = lambda message, *args, **kwargs: None
 
+    def __reduce__(self) -> Tuple[Any, ...]:
+        # This is needed because our parent's implementation could cause us to become a regular
+        # Logger on unpickling.
+        return get_extended_debug_logger, (self.name,)
+
 
 def setup_DEBUG2_logging() -> None:
     """

--- a/newsfragments/199.bugfix.rst
+++ b/newsfragments/199.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure pickling/unpickling an ``ExtendedDebugLogger`` always gives back an ``ExtendedDebugLogger``.

--- a/tests/logging-utils/test_get_logger.py
+++ b/tests/logging-utils/test_get_logger.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 import uuid
 
 from eth_utils.logging import ExtendedDebugLogger, get_extended_debug_logger, get_logger
@@ -55,3 +56,18 @@ def test_get_logger_preserves_logging_module_config():
     assert isinstance(logger, CustomLogger)
 
     assert logging.getLoggerClass() is logging.Logger
+
+
+def test_extended_debug_logger_pickling():
+    name = "testing.{0}".format(uuid.uuid4())
+    extended_logger = get_extended_debug_logger(name)
+    pickled = pickle.dumps(extended_logger)
+
+    # logging.Logger.__reduce__() returns (getLogger, name), which could give us a regular Logger
+    # instance after pickling/unpickling an ExtendedDebugLogger (e.g. when crossing process
+    # boundaries since the other process wouldn't have an ExtendedDebugLogger with that name in
+    # the logging module's cache). This test ensures an unpickled ExtendedDebugLogger is still an
+    # ExtendedDebugLogger even when it's not in the logging's module cache.
+    del logging.Logger.manager.loggerDict[name]
+    unpickled_logger = pickle.loads(pickled)
+    assert isinstance(unpickled_logger, ExtendedDebugLogger)


### PR DESCRIPTION
`logging.Logger.__reduce__()` returns (getLogger, name), which could give
us a regular Logger instance after pickling/unpickling an
ExtendedDebugLogger (e.g. when crossing process boundaries since the
other process wouldn't have an ExtendedDebugLogger with that name in the
logging module's cache).