### PR TITLE
Update a few curried functions for web3 and update mypy

### DIFF
--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Generator, List, Tuple
+from typing import Any, Callable, Dict, Generator, List, Tuple, TypeVar
 import warnings
 
 from .decorators import return_arg_type
@@ -7,6 +7,7 @@ from .toolz import compose, curry
 
 Formatters = Callable[[List[Any]], List[Any]]
 
+TReturn = TypeVar("TReturn")
 
 @return_arg_type(2)
 def apply_formatter_at_index(

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Generator, List, Tuple, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Tuple
 import warnings
 
 from .decorators import return_arg_type
@@ -7,7 +7,6 @@ from .toolz import compose, curry
 
 Formatters = Callable[[List[Any]], List[Any]]
 
-TReturn = TypeVar("TReturn")
 
 @return_arg_type(2)
 def apply_formatter_at_index(

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -10,7 +10,7 @@ from eth_utils import (
     apply_formatter_at_index,
     apply_formatter_if as non_curried_apply_formatter_if,
     apply_formatter_to_array,
-    apply_formatters_to_dict,
+    apply_formatters_to_dict as non_curried_apply_formatters_to_dict,
     apply_formatters_to_sequence,
     apply_key_map,
     apply_one_of_formatters as non_curried_apply_one_of_formatters,
@@ -86,6 +86,8 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
+    Optional,
     Sequence,
     Tuple,
     TypeVar,
@@ -185,26 +187,47 @@ def hexstr_if_str(
 @overload
 def text_if_str(
     to_type: Callable[..., TReturn]
-) -> TReturn:
+) -> Callable[[Union[bytes, int, str]], TReturn]:
     ...
 
 
 @overload
 def text_if_str(
+    to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str]
+) -> TReturn:
+    ...
+
+
+# This is just a stub to appease mypy, it gets overwritten later
+def text_if_str(
     to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str] = None
 ) -> TReturn:
     ...
 
 
-def text_if_str(
-    to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str] = None
+@overload
+def apply_formatters_to_dict(
+    formatters: Dict[Any, Any]
+) -> Callable[[Dict[Any, Any]], TReturn]:
+    ...
+
+@overload
+def apply_formatters_to_dict(
+    formatters: Dict[Any, Any], value: Dict[Any, Any]
+) -> TReturn:
+    ...
+
+
+# This is just a stub to appease mypy, it gets overwritten later
+def apply_formatters_to_dict(
+    formatters: Dict[Any, Any], value: Optional[Dict[Any, Any]] = None
 ) -> TReturn:
     ...
 
 apply_formatter_at_index = curry(apply_formatter_at_index)
 apply_formatter_if = curry(non_curried_apply_formatter_if)
 apply_formatter_to_array = curry(apply_formatter_to_array)
-apply_formatters_to_dict = curry(apply_formatters_to_dict)
+apply_formatters_to_dict = curry(non_curried_apply_formatters_to_dict)
 apply_formatters_to_sequence = curry(apply_formatters_to_sequence)
 apply_key_map = curry(apply_key_map)
 apply_one_of_formatters = curry(non_curried_apply_one_of_formatters)
@@ -223,6 +246,8 @@ clamp = curry(clamp)
 del Any
 del Callable
 del Dict
+del Generator
+del Optional
 del Sequence
 del TReturn
 del TValue
@@ -232,6 +257,7 @@ del Union
 del curry
 del non_curried_apply_formatter_if
 del non_curried_apply_one_of_formatters
+del non_curried_apply_formatters_to_dict
 del non_curried_hexstr_if_str
 del non_curried_text_if_str
 del overload

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -66,7 +66,7 @@ from eth_utils import (
     reversed_return,
     setup_DEBUG2_logging,
     sort_return,
-    text_if_str,
+    text_if_str as non_curried_text_if_str,
     to_bytes,
     to_canonical_address,
     to_checksum_address,
@@ -82,7 +82,16 @@ from eth_utils import (
     to_wei,
 )
 from eth_utils.toolz import curry
-from typing import Any, Callable, Sequence, Tuple, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    overload
+)
 
 TReturn = TypeVar("TReturn")
 TValue = TypeVar("TValue")
@@ -173,6 +182,25 @@ def hexstr_if_str(
     ...
 
 
+@overload
+def text_if_str(
+    to_type: Callable[..., TReturn]
+) -> TReturn:
+    ...
+
+
+@overload
+def text_if_str(
+    to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str] = None
+) -> TReturn:
+    ...
+
+
+def text_if_str(
+    to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str] = None
+) -> TReturn:
+    ...
+
 apply_formatter_at_index = curry(apply_formatter_at_index)
 apply_formatter_if = curry(non_curried_apply_formatter_if)
 apply_formatter_to_array = curry(apply_formatter_to_array)
@@ -184,7 +212,7 @@ from_wei = curry(from_wei)
 get_logger = curry(get_logger)
 hexstr_if_str = curry(non_curried_hexstr_if_str)
 is_same_address = curry(is_same_address)
-text_if_str = curry(text_if_str)
+text_if_str = curry(non_curried_text_if_str)
 to_wei = curry(to_wei)
 clamp = curry(clamp)
 
@@ -194,6 +222,7 @@ clamp = curry(clamp)
 #   importing the wrong thing, while __all__ only affects `from eth_utils.curried import *`
 del Any
 del Callable
+del Dict
 del Sequence
 del TReturn
 del TValue
@@ -204,4 +233,5 @@ del curry
 del non_curried_apply_formatter_if
 del non_curried_apply_one_of_formatters
 del non_curried_hexstr_if_str
+del non_curried_text_if_str
 del overload

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -92,7 +92,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    overload
+    overload,
 )
 
 TReturn = TypeVar("TReturn")
@@ -211,6 +211,7 @@ def apply_formatters_to_dict(
 ) -> Callable[[Dict[Any, Any]], TReturn]:
     ...
 
+
 @overload
 def apply_formatters_to_dict(
     formatters: Dict[Any, Any], value: Dict[Any, Any]
@@ -223,6 +224,7 @@ def apply_formatters_to_dict(
     formatters: Dict[Any, Any], value: Optional[Dict[Any, Any]] = None
 ) -> TReturn:
     ...
+
 
 apply_formatter_at_index = curry(apply_formatter_at_index)
 apply_formatter_if = curry(non_curried_apply_formatter_if)

--- a/newsfragments/201.feature.rst
+++ b/newsfragments/201.feature.rst
@@ -1,0 +1,2 @@
+Added a new type signature of apply_formatter_if to eth_utils curried module.
+Also added text_if_str and apply_formatters_to_dict.

--- a/newsfragments/201.misc.rst
+++ b/newsfragments/201.misc.rst
@@ -1,0 +1,1 @@
+Updated mypy to 0.720, and added a deprecation warning check

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         'black>=18.6b4,<19',
         'flake8>=3.7.0,<4.0.0',
         "isort==4.3.18",
-        'mypy==0.701',
+        'mypy==0.720',
         'pytest>=3.4.1,<4.0.0',
     ],
     'test': [

--- a/tests/applicator-utils/test_applicators.py
+++ b/tests/applicator-utils/test_applicators.py
@@ -159,7 +159,8 @@ LOOSE_SEQUENCE_FORMATTER_PARAMETERS = SEQUENCE_FORMATTER_PARAMETERS + (
     "formatters, value, expected", LOOSE_SEQUENCE_FORMATTER_PARAMETERS
 )
 def test_combine_argument_formatters(formatters, value, expected):
-    list_formatter = eth_utils.combine_argument_formatters(*formatters)
+    with pytest.warns(DeprecationWarning):
+        list_formatter = eth_utils.combine_argument_formatters(*formatters)
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
             list_formatter(value)

--- a/tests/functional-utils/type_inference_tests.py
+++ b/tests/functional-utils/type_inference_tests.py
@@ -32,37 +32,37 @@ def check_mypy_run(
         (
             fixture_dir("to_tuple_decorator.py"),
             fixture_dir(
-                "to_tuple_decorator.py:13: error: Revealed type is 'builtins.tuple[builtins.int*]'\n"  # noqa: E501
+                "to_tuple_decorator.py:13: note: Revealed type is 'builtins.tuple[builtins.int*]'\n"  # noqa: E501
             ),
         ),
         (
             fixture_dir("to_list_decorator.py"),
             fixture_dir(
-                "to_list_decorator.py:13: error: Revealed type is 'builtins.list[builtins.int*]'\n"
+                "to_list_decorator.py:13: note: Revealed type is 'builtins.list[builtins.int*]'\n"
             ),
         ),
         (
             fixture_dir("to_set_decorator.py"),
             fixture_dir(
-                "to_set_decorator.py:14: error: Revealed type is 'builtins.set[builtins.int*]'\n"
+                "to_set_decorator.py:14: note: Revealed type is 'builtins.set[builtins.int*]'\n"
             ),
         ),
         (
             fixture_dir("to_dict_decorator.py"),
             fixture_dir(
-                "to_dict_decorator.py:14: error: Revealed type is 'builtins.dict[builtins.int*, builtins.int*]'\n"  # noqa: E501
+                "to_dict_decorator.py:14: note: Revealed type is 'builtins.dict[builtins.int*, builtins.int*]'\n"  # noqa: E501
             ),
         ),
         (
             fixture_dir("to_ordered_dict_decorator.py"),
             fixture_dir(
-                "to_ordered_dict_decorator.py:14: error: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.int*]'\n"  # noqa: E501
+                "to_ordered_dict_decorator.py:14: note: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.int*]'\n"  # noqa: E501
             ),
         ),
         (
             fixture_dir("apply_to_return_value_decorator.py"),
             fixture_dir(
-                "apply_to_return_value_decorator.py:17: error: Revealed type is 'builtins.list*[builtins.int]'\n"  # noqa: E501
+                "apply_to_return_value_decorator.py:17: note: Revealed type is 'builtins.list*[builtins.int]'\n"  # noqa: E501
             ),
         ),
     ),


### PR DESCRIPTION
### What was wrong?
- Web3py needed some curried functions, so I added those. 
- Bumped up mypy because typed-ast doesn't work with python 3.8
- Got rid of some deprecation warnings in the tests

Let me know if I should split this into 3 PRs.

### How was it fixed?
Following [this PR](https://github.com/ethereum/eth-utils/pull/200)


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="352" alt="image" src="https://user-images.githubusercontent.com/6540608/91619180-9af73c80-e949-11ea-83d6-c98c4668f16b.png">

