### PR TITLE
Cleanup / optimization of is_hexstr().

### DIFF
--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -8,7 +8,7 @@ from eth_typing import HexStr
 
 from .types import is_string, is_text
 
-_HEX_REGEXP = re.compile("[0-9a-fA-F]*")
+_HEX_REGEXP = re.compile("(0x)?[0-9a-f]*", re.IGNORECASE | re.ASCII)
 
 
 def decode_hex(value: str) -> bytes:
@@ -53,37 +53,9 @@ def add_0x_prefix(value: HexStr) -> HexStr:
 
 
 def is_hexstr(value: Any) -> bool:
-    if not is_text(value):
+    if not is_text(value) or not value:
         return False
-
-    elif value.lower() == "0x":
-        return True
-
-    unprefixed_value = remove_0x_prefix(value)
-    if len(unprefixed_value) % 2 != 0:
-        value_to_decode = "0" + unprefixed_value
-    else:
-        value_to_decode = unprefixed_value
-
-    if not _HEX_REGEXP.fullmatch(value_to_decode):
-        return False
-
-    try:
-        # convert from a value like '09af' to b'09af'
-        ascii_hex = value_to_decode.encode("ascii")
-    except UnicodeDecodeError:
-        # Should have already been caught by regex above, but just in case...
-        return False
-
-    try:
-        # convert to a value like b'\x09\xaf'
-        value_as_bytes = binascii.unhexlify(ascii_hex)
-    except binascii.Error:
-        return False
-    except TypeError:
-        return False
-    else:
-        return bool(value_as_bytes)
+    return _HEX_REGEXP.fullmatch(value) is not None
 
 
 def is_hex(value: Any) -> bool:

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -63,31 +63,6 @@ def is_hex(value: Any) -> bool:
         raise TypeError(
             "is_hex requires text typed arguments. Got: {0}".format(repr(value))
         )
-    elif value.lower() == "0x":
-        return True
-
-    unprefixed_value = remove_0x_prefix(value)
-    if len(unprefixed_value) % 2 != 0:
-        value_to_decode = "0" + unprefixed_value
-    else:
-        value_to_decode = unprefixed_value
-
-    if not _HEX_REGEXP.fullmatch(value_to_decode):
+    if not value:
         return False
-
-    try:
-        # convert from a value like '09af' to b'09af'
-        ascii_hex = value_to_decode.encode("ascii")
-    except UnicodeDecodeError:
-        # Should have already been caught by regex above, but just in case...
-        return False
-
-    try:
-        # convert to a value like b'\x09\xaf'
-        value_as_bytes = binascii.unhexlify(ascii_hex)
-    except binascii.Error:
-        return False
-    except TypeError:
-        return False
-    else:
-        return bool(value_as_bytes)
+    return _HEX_REGEXP.fullmatch(value) is not None


### PR DESCRIPTION
I don't understand why all this code was present : if it's valid hex it will be decoded successfully, there is no way otherwise.

This also makes it faster because it's only about matching a regexp now. And simpler to understand.

All tests are passing.