### PR TITLE
Raise known error instead of a blind re-raise

### DIFF
--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -82,10 +82,17 @@ def apply_formatters_to_dict(
         if key in formatters:
             try:
                 yield key, formatters[key](item)
-            except (TypeError, ValueError) as exc:
-                raise type(exc)(
-                    "Could not format value %r as field %r" % (item, key)
-                ) from exc
+            except ValueError as exc:
+                new_error_message = "Could not format invalid value %r as field %r" % (
+                    item,
+                    key,
+                )
+                raise ValueError(new_error_message) from exc
+            except TypeError as exc:
+                new_error_message = (
+                    "Could not format invalid type of %r for field %r" % (item, key)
+                )
+                raise TypeError(new_error_message) from exc
         else:
             yield key, item
 


### PR DESCRIPTION
When catching a TypeError or ValueError, we can't necessarily
re-initialize it with a string message argument. For example, a
JSONDecodeError requires a `doc` and `pos` argument.

Instead, we just re-raise with a new TypeError or ValueError, depending
on the subclass caught.

### What was wrong?

Got an inscrutable error message:
```
~/code/ens-doteth/venv-py3.8.0/lib/python3.8/site-packages/eth_utils/applicators.py in apply_formatters_to_dict(formatters, value)
     84                 yield key, formatters[key](item)
     85             except (TypeError, ValueError) as exc:
---> 86                 raise type(exc)(
     87                     "Could not format value %r as field %r" % (item, key)
     88                 ) from exc

TypeError: __init__() missing 2 required positional arguments: 'doc' and 'pos'
```

Turns out that it was a `JSONDecodeError` being raised, which can't be re-instantiated with only a string argument.

### How was it fixed?

Explicitly raise a `TypeError` or `ValueError` instead of trying to re-instantiate the caught exception.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/dc/b1/3c/dcb13c61907ef48fcb4a4dc83233fbd4.jpg)