### PR TITLE
Allow Address as input to address conversions

### DIFF
--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -1,4 +1,4 @@
-from typing import Any, AnyStr
+from typing import Any, Union
 
 from eth_typing import Address, AnyAddress, ChecksumAddress, HexAddress, HexStr
 
@@ -52,7 +52,7 @@ def is_address(value: Any) -> bool:
         return False
 
 
-def to_normalized_address(value: AnyStr) -> HexAddress:
+def to_normalized_address(value: Union[AnyAddress, str, bytes]) -> HexAddress:
     """
     Converts an address to its normalized hexadecimal representation.
     """
@@ -80,7 +80,7 @@ def is_normalized_address(value: Any) -> bool:
         return value == to_normalized_address(value)
 
 
-def to_canonical_address(address: AnyStr) -> Address:
+def to_canonical_address(address: Union[AnyAddress, str, bytes]) -> Address:
     """
     Given any supported representation of an address
     returns its canonical form (20 byte long string).
@@ -107,7 +107,7 @@ def is_same_address(left: AnyAddress, right: AnyAddress) -> bool:
         return to_normalized_address(left) == to_normalized_address(right)
 
 
-def to_checksum_address(value: AnyStr) -> ChecksumAddress:
+def to_checksum_address(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
     """
     Makes a checksum address given a supported format.
     """

--- a/newsfragments/205.bugfix.rst
+++ b/newsfragments/205.bugfix.rst
@@ -1,0 +1,2 @@
+Update the type signature of to_canonical_address, to_checksum_address, and to_normalized_address to
+allow `bytes`-typed address input.

--- a/tests/address-utils/test_address_utils.py
+++ b/tests/address-utils/test_address_utils.py
@@ -219,11 +219,19 @@ def test_to_normalized_address(value, expected):
             "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
         ),
         (
+            b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
+            "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+        ),
+        (
             "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
             "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
         ),
         (
             "c6d9d2cd449a754c494264e1809c50e34d64562b",
+            "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
+        ),
+        (
+            b"\xc6\xd9\xd2\xcdD\x9auLIBd\xe1\x80\x9cP\xe3MdV+",
             "0xc6d9d2cD449A754c494264e1809c50e34D64562b",
         ),
     ),
@@ -270,6 +278,10 @@ def test_is_same_address(address1, address2, expected):
         ),
         (
             "0xD3CDA913DEB6F67967B99D67ACDFA1712C293601",
+            b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
+        ),
+        (
+            b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
             b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",
         ),
     ),


### PR DESCRIPTION
### What was wrong?

These methods actually support canonical address inputs, but didn't have tests or type signatures that indicate so:

- to_canonical_address
- to_checksum_address
- to_normalized_address

### How was it fixed?

Add tests, update type annotations.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/205327/104381011-bd48bb80-54e0-11eb-94f2-6b583acb4359.jpeg)
