### PR TITLE
Release notes template

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,5 +1,12 @@
-Eth_Utils 1.9.5 (2020-08-31)
-----------------------------
+Release Notes
+=============
+
+Read up on all the latest improvements.
+
+.. towncrier release notes start
+
+eth-utils v1.9.5 (2020-08-31)
+-----------------------------
 
 Bugfixes
 ~~~~~~~~
@@ -14,8 +21,8 @@ Misc
 - `#201 <https://github.com/ethereum/eth-utils/issues/201>`__
 
 
-Eth_Utils 1.9.4 (2020-08-25)
-----------------------------
+eth-utils v1.9.4 (2020-08-25)
+-----------------------------
 
 Bugfixes
 ~~~~~~~~
@@ -26,8 +33,8 @@ Bugfixes
 - Ensure pickling/unpickling an ``ExtendedDebugLogger`` always gives back an ``ExtendedDebugLogger``. (`#199 <https://github.com/ethereum/eth-utils/issues/199>`__)
 
 
-Eth_Utils 1.9.0 (2020-05-11)
-----------------------------
+eth-utils v1.9.0 (2020-05-11)
+-----------------------------
 
 Features
 ~~~~~~~~

--- a/newsfragments/202.performance.rst
+++ b/newsfragments/202.performance.rst
@@ -1,0 +1,2 @@
+Speed up :meth:`eth_utils.hexadecimal.is_hex` and :meth:`eth_utils.hexadecimal.is_hexstr` by
+compiling the logic into a regex.

--- a/newsfragments/203.performance.rst
+++ b/newsfragments/203.performance.rst
@@ -1,0 +1,2 @@
+Speed up :meth:`eth_utils.address.is_address` by avoiding some duplicate work. Estimated speedup is
+40%.

--- a/newsfragments/204.bugfix.rst
+++ b/newsfragments/204.bugfix.rst
@@ -1,0 +1,4 @@
+:meth:`eth_utils.applicators.apply_formatters_to_dict` was crashing when it was trying to re-raise
+certain subclasses of `ValueError` and `TypeError`, like `JSONDecodeError`. This was hiding the
+original exception, and making it very difficult to debug. Instead of trying to re-raise the
+original exception type, we now reraise a simple `ValueError` or `TypeError`.

--- a/newsfragments/206.docs.rst
+++ b/newsfragments/206.docs.rst
@@ -1,0 +1,1 @@
+Move release notes, and keep them from spamming the eth-utils docs home page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@
     filename = "docs/releases.rst"
     directory = "newsfragments"
     underlines = ["-", "~", "^"]
+    title_format = "eth-utils v{version} ({project_date})"
     issue_format = "`#{issue} <https://github.com/ethereum/eth-utils/issues/{issue}>`__"


### PR DESCRIPTION
### What was wrong?

There was no title on the release notes page, so all the inner titles were spamming the docs homepage on https://eth-utils.readthedocs.io/en/stable/

### How was it fixed?

- Add a title
- Clean up the eth-utils name in each sub-heading
- Add a few missed release notes from previous merges

### To-Do

- [ ] Merge in project template to get the latest options for docs like `*.performance.rst`, `*.docs.rst`, etc

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/58/ac/d7/58acd772e5e3aabbe60bc14479b3c7a0--cutest-baby-animals-adorable-animals.jpg)
