### PR TITLE
Upgrade eth-hash to v0.3.0

### DIFF
--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -1,4 +1,4 @@
-from typing import Union, cast
+from typing import Union
 
 from eth_hash.auto import keccak as keccak_256
 
@@ -8,5 +8,4 @@ from .conversions import to_bytes
 def keccak(
     primitive: Union[bytes, int, bool] = None, hexstr: str = None, text: str = None
 ) -> bytes:
-    input_bytes = to_bytes(primitive, hexstr, text)
-    return cast(bytes, keccak_256(input_bytes))
+    return keccak_256(to_bytes(primitive, hexstr, text))

--- a/newsfragments/208.internal.rst
+++ b/newsfragments/208.internal.rst
@@ -1,0 +1,1 @@
+Upgrade eth-hash to v0.3.1, to use its exported type annotations instead of casting the results.

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url='https://github.com/ethereum/eth-utils',
     include_package_data=True,
     install_requires=[
-        "eth-hash>=0.1.0,<0.3.0",
+        "eth-hash>=0.3.1,<0.4.0",
         "eth-typing>=2.2.1,<3.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",
         "cytoolz>=0.10.1,<1.0.0;implementation_name=='cpython'",


### PR DESCRIPTION
## What was wrong?

Have to cast/ignore the types from eth-hash, because they weren't being executed.

## How was it fixed?

Get the latest type exports from eth-hash v0.3.0

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/564x/70/20/ff/7020ff4df0c4a8f134001494ef6ee741.jpg)