### PR TITLE
fixing wrapped function signatures by improving decorator annotations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.linting.flake8Enabled": true,
+    "python.languageServer": "Pylance",
+    "python.linting.flake8Args": [
+        "max-line-length=100"
+    ]
+}

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -7,6 +7,7 @@ from .types import is_text
 T = TypeVar("T")
 _C = TypeVar("_C", bound=Callable[..., Any])
 
+
 class combomethod(object):
     def __init__(self, method: Callable[..., Any]) -> None:
         self.method = method

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -67,7 +67,7 @@ def validate_conversion_arguments(to_wrap: _C) -> _C:
     """
 
     @functools.wraps(to_wrap)
-    def wrapper(*args: Any, **kwargs: Any):
+    def wrapper(*args: Any, **kwargs: Any) -> _C:
         _assert_one_val(*args, **kwargs)
         if kwargs:
             _validate_supported_kwarg(kwargs)
@@ -106,7 +106,7 @@ def replace_exceptions(
 
     def decorator(to_wrap: _C) -> _C:
         @functools.wraps(to_wrap)
-        def wrapped(*args: Any, **kwargs: Any):
+        def wrapped(*args: Any, **kwargs: Any) -> _C:
             try:
                 return to_wrap(*args, **kwargs)
             except old_exceptions as err:

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Type, TypeVar
 from .types import is_text
 
 T = TypeVar("T")
-
+_C = TypeVar("_C", bound=Callable[..., Any])
 
 class combomethod(object):
     def __init__(self, method: Callable[..., Any]) -> None:
@@ -57,7 +57,7 @@ def _validate_supported_kwarg(kwargs: Any) -> None:
         )
 
 
-def validate_conversion_arguments(to_wrap: Callable[..., T]) -> Callable[..., T]:
+def validate_conversion_arguments(to_wrap: _C) -> _C:
     """
     Validates arguments for conversion functions.
     - Only a single argument is present
@@ -66,7 +66,7 @@ def validate_conversion_arguments(to_wrap: Callable[..., T]) -> Callable[..., T]
     """
 
     @functools.wraps(to_wrap)
-    def wrapper(*args: Any, **kwargs: Any) -> T:
+    def wrapper(*args: Any, **kwargs: Any):
         _assert_one_val(*args, **kwargs)
         if kwargs:
             _validate_supported_kwarg(kwargs)
@@ -78,14 +78,14 @@ def validate_conversion_arguments(to_wrap: Callable[..., T]) -> Callable[..., T]
     return wrapper
 
 
-def return_arg_type(at_position: int) -> Callable[..., Callable[..., T]]:
+def return_arg_type(at_position: int) -> Callable[[_C], _C]:
     """
     Wrap the return value with the result of `type(args[at_position])`.
     """
 
-    def decorator(to_wrap: Callable[..., Any]) -> Callable[..., T]:
+    def decorator(to_wrap: _C) -> _C:
         @functools.wraps(to_wrap)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
+        def wrapper(*args: Any, **kwargs: Any):
             result = to_wrap(*args, **kwargs)
             ReturnType = type(args[at_position])
             return ReturnType(result)  # type: ignore
@@ -97,15 +97,15 @@ def return_arg_type(at_position: int) -> Callable[..., Callable[..., T]]:
 
 def replace_exceptions(
     old_to_new_exceptions: Dict[Type[BaseException], Type[BaseException]]
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
+) -> Callable[[_C], _C]:
     """
     Replaces old exceptions with new exceptions to be raised in their place.
     """
     old_exceptions = tuple(old_to_new_exceptions.keys())
 
-    def decorator(to_wrap: Callable[..., T]) -> Callable[..., T]:
+    def decorator(to_wrap: _C) -> _C:
         @functools.wraps(to_wrap)
-        def wrapped(*args: Any, **kwargs: Any) -> T:
+        def wrapped(*args: Any, **kwargs: Any):
             try:
                 return to_wrap(*args, **kwargs)
             except old_exceptions as err:


### PR DESCRIPTION
## What was wrong?

Issue #

The decorator for `validate_conversion_arguments` doesn’t preserve the input arguments to the decorated function. It’s using a `Callable[…, T]` for both input and output, and there’s no correlation between the `…` on the input and the `…` on the output. 

![image](https://user-images.githubusercontent.com/1946977/117256806-f98d8800-adff-11eb-9c25-1dcfbff20850.png)


## How was it fixed?

![image](https://user-images.githubusercontent.com/1946977/117256911-1aee7400-ae00-11eb-92e4-62ef98560b46.png)


Summary of approach.
the best approach is to use PEP 612 (ParamSpec) but that is not out till python 3.10

```
_P = ParamSpec("_P")
_R = TypeVar("_R")
 
def validate_conversion_arguments(to_wrap: Callable[_P, _R]) -> Callable[_P, _R]:

    @functools.wraps(to_wrap)
    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R: 
        return to_wrap(*args, **kwargs)
    return wrapper
```

By mapping it to a type `_C` we can now show that the input and output signatures should match and we will no longer lose detailed function signatures in pylance/pright language servers

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://th.bing.com/th/id/OIP.bfeRAGUD-iBbIFZpspHsowHaE8?w=282&h=188&c=7&o=5&dpr=1.1&pid=1.7)
