### PR TITLE
Adapte les fonctionnalités checksum à RSKIP60 et EIP55

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        ".",
+        "-p",
+        "*test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.unittestEnabled": false,
+    "python.testing.promptToConfigure": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     "python.testing.pytestEnabled": false,
     "python.testing.nosetestsEnabled": false,
     "python.testing.unittestEnabled": false,
-    "python.testing.promptToConfigure": false
+    "python.testing.promptToConfigure": false,
+    "svn.ignoreMissingSvnWarning": true
 }

--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -107,12 +107,14 @@ def is_same_address(left: AnyAddress, right: AnyAddress) -> bool:
         return to_normalized_address(left) == to_normalized_address(right)
 
 
-def to_checksum_address(value: AnyStr) -> ChecksumAddress:
+def to_checksum_address(value: AnyStr, chain_id: int = 1) -> ChecksumAddress:
     """
     Makes a checksum address given a supported format.
     """
     norm_address = to_normalized_address(value)
-    address_hash = encode_hex(keccak(text=remove_0x_prefix(HexStr(norm_address))))
+    address_hash = encode_hex(
+        keccak(text=remove_0x_prefix(HexStr(norm_address), chain_id))
+    )
 
     checksum_address = add_0x_prefix(
         HexStr(
@@ -122,20 +124,20 @@ def to_checksum_address(value: AnyStr) -> ChecksumAddress:
                     if int(address_hash[i], 16) > 7
                     else norm_address[i]
                 )
-                for i in range(2, 42)
+                for i in range(2, len(norm_address))
             )
         )
     )
     return ChecksumAddress(HexAddress(checksum_address))
 
 
-def is_checksum_address(value: Any) -> bool:
+def is_checksum_address(value: Any, chain_id: int = 1) -> bool:
     if not is_text(value):
         return False
 
     if not is_hex_address(value):
         return False
-    return value == to_checksum_address(value)
+    return value == to_checksum_address(value, chain_id)
 
 
 def is_checksum_formatted_address(value: Any) -> bool:

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -97,5 +97,8 @@ is_same_address = curry(is_same_address)
 text_if_str = curry(text_if_str)
 to_wei = curry(to_wei)
 clamp = curry(clamp)
+is_checksum_address = curry(is_checksum_address)
+remove_0x_prefix = curry(remove_0x_prefix)
+to_checksum_address = curry(to_checksum_address)
 
 del curry

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -40,9 +40,9 @@ def is_0x_prefixed(value: Any) -> bool:
     return value.startswith("0x") or value.startswith("0X")
 
 
-def remove_0x_prefix(value: HexStr) -> HexStr:
+def remove_0x_prefix(value: HexStr, chain_id: int = 1) -> HexStr:
     if is_0x_prefixed(value):
-        return HexStr(value[2:])
+        return HexStr(value[2:] if chain_id == 1 else str(chain_id) + value)
     return value
 
 


### PR DESCRIPTION
Adapts checksum functionality to RSKIP60 and EIP55

## What was wrong?

Issue #

## How was it fixed?

Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
