### PR TITLE
fix typo

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1145,7 +1145,7 @@ returned by the callable.
    >>> f(3)
    6
 
-Hexidecimal Utils
+Hexadecimal Utils
 ~~~~~~~~~~~~~~~~~
 
 ``add_0x_prefix(value: HexStr)`` -> HexStr_
@@ -1326,11 +1326,11 @@ Returns the provide number of seconds as a shorthand string.
 
 Returns the provided byte string in a human readable format.
 
-If the value is 5 bytes or less it is returned in full in its hexidecimal representation (without a ``0x`` prefix)
+If the value is 5 bytes or less it is returned in full in its hexadecimal representation (without a ``0x`` prefix)
 
-If the value is longer that 5 bytes it is returned in its hexidecimal
+If the value is longer that 5 bytes it is returned in its hexadecimal
 representation (without a ``0x`` prefix) with the middle segment replaced by an
-ellipsis, only showing the first and last four hexidecimal nibbles.
+ellipsis, only showing the first and last four hexadecimal nibbles.
 
 .. doctest::
 

--- a/newsfragments/222.doc.rst
+++ b/newsfragments/222.doc.rst
@@ -1,0 +1,1 @@
+Fix typo in documentation: hexidecimal -> hexadecimal


### PR DESCRIPTION
## What was wrong?

Typo on utilies.rst

## How was it fixed?

Change "hexidecimal" to "hexadecimal"

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [X] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://blizzardwatch.com/wp-content/uploads/2021/09/otter-header.png)
