### PR TITLE
Hexadecimal optimizations

### DIFF
--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -8,7 +8,7 @@ from eth_typing import HexStr
 
 from .types import is_string, is_text
 
-_HEX_REGEXP = re.compile("(0x)?[0-9a-f]*", re.IGNORECASE | re.ASCII)
+_HEX_REGEXP = re.compile("(0[xX])?[0-9a-fA-F]*")
 
 
 def decode_hex(value: str) -> bytes:

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -37,7 +37,7 @@ def is_0x_prefixed(value: str) -> bool:
         raise TypeError(
             "is_0x_prefixed requires text typed arguments. Got: {0}".format(repr(value))
         )
-    return value.startswith("0x") or value.startswith("0X")
+    return value.startswith(("0x", "0X"))
 
 
 def remove_0x_prefix(value: HexStr) -> HexStr:

--- a/newsfragments/223.performance.rst
+++ b/newsfragments/223.performance.rst
@@ -1,0 +1,1 @@
+Performance improvement of up to 65% on ``is_0x_prefixed``


### PR DESCRIPTION
## What was wrong?

Nothing wrong, simply trying to improve performances here, and there.

## How was it fixed?

I used that script to naively benchmark changes for the 2nd commit:

```python
import re
from timeit import timeit


def original(value, regex=re.compile("(0x)?[0-9a-f]*", re.IGNORECASE | re.ASCII)):
    return regex.fullmatch(value) is not None


def new(value, regex=re.compile("(0[xX])?[0-9a-fA-F]*")):
    return regex.fullmatch(value) is not None


print("original(True)", timeit(
    "original('0x5831e66b7de5df2d8d4705c86c844ff60a50efcec53f9449b16dc43216a783f7')", "from __main__ import original"))
print("new(True)", timeit(
    "new('0x5831e66b7de5df2d8d4705c86c844ff60a50efcec53f9449b16dc43216a783f7')", "from __main__ import new"))
print()
print("original(False)", timeit(
    "original('0x5831e66b7de5df2d8d4705c86c844ff60a50efcec53f9449b16dc43216a783f7g')", "from __main__ import original"))
print("new(False)", timeit(
    "new('0x5831e66b7de5df2d8d4705c86c844ff60a50efcec53f9449b16dc43216a783f7g')", "from __main__ import new"))
```

Improvements unlocked by the first commit:

- When `value` has 0x prefix:
  - before: 0.1212 sec
  - after : 0.1132 sec (-6.6 %)

- When `value` has 0X prefix:
  - before: 0.1976 sec
  - after : 0.1167 sec (-40.9 %)

- When `value` has no 0x prefix:
  - before: 0.1918 sec
  - after : 0.1165 sec (-39.2 %)

Improvements unlocked by the 2nd commit:

- When `value` is hexadecimal string (TX hash):
  - before: 1.0965 sec
  - after : 0.3652 sec (-66.7 %)

- When `value` is not hexadecimal string (TX hash + 'g'):
  - before: 1.4546 sec
  - after : 0.7022 sec (-51.7 %)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://justsomething.co/wp-content/uploads/2014/04/most-adorable-animals-8.jpg)
