### PR TITLE
Update mypy, fix new errors

### DIFF
--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -61,7 +61,9 @@ def to_normalized_address(value: Union[AnyAddress, str, bytes]) -> HexAddress:
         return HexAddress(HexStr(hex_address))
     else:
         raise ValueError(
-            "Unknown format {}, attempted to normalize to {}".format(value, hex_address)
+            "Unknown format {!r}, attempted to normalize to {!r}".format(
+                value, hex_address
+            )
         )
 
 

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -13,7 +13,7 @@ TLogger = TypeVar("TLogger", bound=logging.Logger)
 class cached_show_debug2_property:
     def __init__(self, func: Callable[[TLogger], bool]):
         # type ignored b/c arg1 expects Callable[..., Any]
-        functools.update_wrapper(self, func)  # type: ignore
+        functools.update_wrapper(self, func)
         self._func = func
 
     def __get__(self, obj: Optional[TLogger], cls: Type[logging.Logger]) -> Any:
@@ -80,7 +80,7 @@ def get_logger(name: str, logger_class: Type[TLogger] = None) -> TLogger:
             # the global logging class changes.
             #
             # types ignored b/c mypy doesn't identify presence of manager on logging.Logger
-            manager = logging.Logger.manager  # type: ignore
+            manager = logging.Logger.manager
             if name in manager.loggerDict:
                 if type(manager.loggerDict[name]) is not logger_class:
                     del manager.loggerDict[name]
@@ -109,7 +109,7 @@ class HasLoggerMeta(type):
         name: str,
         bases: Tuple[Type[Any]],
         namespace: Dict[str, Any],
-    ) -> type:
+    ) -> THasLoggerMeta:
         if "logger" in namespace:
             # If a logger was explicitly declared we shouldn't do anything to
             # replace it.

--- a/newsfragments/226.misc.rst
+++ b/newsfragments/226.misc.rst
@@ -1,0 +1,1 @@
+Update mypy version to work with python 3.10

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 
 [pytest-watch]

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,10 @@ extras_require = {
         "black>=18.6b4,<19",
         "flake8==3.7.9",
         "isort>=4.2.15,<5",
-        "mypy==0.720",
+        "mypy==0.910",
         "pydocstyle>=5.0.0,<6",
         "pytest>=6.2.5,<7",
+        "types-setuptools",
     ],
     "doc": [
         "Sphinx>=1.6.5,<2",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         "pytest>=6.2.5,<7",
         "pytest-xdist",
         "tox==3.14.6",
+        "types-setuptools",
     ],
     "lint": [
         "black>=18.6b4,<19",

--- a/tests/functional-utils/type_inference_tests.py
+++ b/tests/functional-utils/type_inference_tests.py
@@ -32,37 +32,37 @@ def check_mypy_run(
         (
             fixture_dir("to_tuple_decorator.py"),
             fixture_dir(
-                "to_tuple_decorator.py:13: note: Revealed type is 'builtins.tuple[builtins.int*]'\n"  # noqa: E501
+                'to_tuple_decorator.py:13: note: Revealed type is "builtins.tuple[builtins.int*]"\n'  # noqa: E501
             ),
         ),
         (
             fixture_dir("to_list_decorator.py"),
             fixture_dir(
-                "to_list_decorator.py:13: note: Revealed type is 'builtins.list[builtins.int*]'\n"
+                'to_list_decorator.py:13: note: Revealed type is "builtins.list[builtins.int*]"\n'
             ),
         ),
         (
             fixture_dir("to_set_decorator.py"),
             fixture_dir(
-                "to_set_decorator.py:14: note: Revealed type is 'builtins.set[builtins.int*]'\n"
+                'to_set_decorator.py:14: note: Revealed type is "builtins.set[builtins.int*]"\n'
             ),
         ),
         (
             fixture_dir("to_dict_decorator.py"),
             fixture_dir(
-                "to_dict_decorator.py:14: note: Revealed type is 'builtins.dict[builtins.int*, builtins.int*]'\n"  # noqa: E501
+                'to_dict_decorator.py:14: note: Revealed type is "builtins.dict[builtins.int*, builtins.int*]"\n'  # noqa: E501
             ),
         ),
         (
             fixture_dir("to_ordered_dict_decorator.py"),
             fixture_dir(
-                "to_ordered_dict_decorator.py:14: note: Revealed type is 'collections.OrderedDict[builtins.int*, builtins.int*]'\n"  # noqa: E501
+                'to_ordered_dict_decorator.py:14: note: Revealed type is "collections.OrderedDict[builtins.int*, builtins.int*]"\n'  # noqa: E501
             ),
         ),
         (
             fixture_dir("apply_to_return_value_decorator.py"),
             fixture_dir(
-                "apply_to_return_value_decorator.py:17: note: Revealed type is 'builtins.list*[builtins.int]'\n"  # noqa: E501
+                'apply_to_return_value_decorator.py:17: note: Revealed type is "builtins.list*[builtins.int]"\n'  # noqa: E501
             ),
         ),
     ),


### PR DESCRIPTION
## What was wrong?
mypy v0.720 isn't compatible with Python 3.10.


## How was it fixed?

Bumped the mypy version requirement and fixed new errors. Also had to do some mucking around with `docs/conf.py` and `.bumpversion.cfg` because of black autoformatting. The autoformatting changes are duplicated in #225.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.istockphoto.com/photos/wild-adult-florida-gopher-tortoise-gopherus-polyphemus-crossing-line-picture-id1337505006?k=20&m=1337505006&s=612x612&w=0&h=FH-nqyZilvGFRitU2u9jJ7oM7P1XcLAb5SZoizkthz8=)
