### PR TITLE
fix: update the return type to 'Hash32'

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -717,8 +717,8 @@ being supplied when passing in a ``str``.
 
 Only supply one of the arguments:
 
-``keccak(<bytes/int/bool>, text=<str>, hexstr=<str>)`` -> bytes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``keccak(<bytes/int/bool>, text=<str>, hexstr=<str>)`` -> Hash32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. doctest::
 

--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -29,6 +29,7 @@ from eth_typing import (
     ABIFallback,
     ABIFunction,
     ABIReceive,
+    Hash32,
 )
 
 from eth_utils.types import (
@@ -818,7 +819,7 @@ def function_abi_to_4byte_selector(abi_element: ABIElement) -> bytes:
     return function_signature_to_4byte_selector(function_signature)
 
 
-def event_signature_to_log_topic(event_signature: str) -> bytes:
+def event_signature_to_log_topic(event_signature: str) -> Hash32:
     r"""
     Return the 32-byte keccak signature of the log topic for an event signature.
 
@@ -836,7 +837,7 @@ def event_signature_to_log_topic(event_signature: str) -> bytes:
     return keccak(text=event_signature.replace(" ", ""))
 
 
-def event_abi_to_log_topic(event_abi: ABIEvent) -> bytes:
+def event_abi_to_log_topic(event_abi: ABIEvent) -> Hash32:
     r"""
     Return the 32-byte keccak signature of the log topic from an event ABI.
 

--- a/eth_utils/crypto.py
+++ b/eth_utils/crypto.py
@@ -6,6 +6,9 @@ from typing import (
 from eth_hash.auto import (
     keccak as keccak_256,
 )
+from eth_typing import (
+    Hash32,
+)
 
 from .conversions import (
     to_bytes,
@@ -16,5 +19,5 @@ def keccak(
     primitive: Optional[Union[bytes, int, bool]] = None,
     hexstr: Optional[str] = None,
     text: Optional[str] = None,
-) -> bytes:
-    return bytes(keccak_256(to_bytes(primitive, hexstr, text)))
+) -> Hash32:
+    return Hash32(keccak_256(to_bytes(primitive, hexstr, text)))

--- a/newsfragments/230.breaking.rst
+++ b/newsfragments/230.breaking.rst
@@ -1,0 +1,1 @@
+Update the return type from ``bytes`` to ``Hash32`` for all ``keccak`` methods


### PR DESCRIPTION
## What was wrong?

Issue #192

## How was it fixed?

Update the return type from `bytes` to `Hash32` for all methods that apply `keccak`.
I explicitly cast the return type of `eth_hash.auto.keccak` to `Hash32` in crypto.py, since its return type is `bytes`, maybe this should be fixed in eth_hash too.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/profile_images/1353075738358910977/0N3HhghG_400x400.jpg)
