### PR TITLE
test: add currency tests with float ether input

### DIFF
--- a/newsfragments/231.internal.rst
+++ b/newsfragments/231.internal.rst
@@ -1,0 +1,1 @@
+Add currency tests with float ether inputs.

--- a/tests/currency-utils/test_currency_tools.py
+++ b/tests/currency-utils/test_currency_tools.py
@@ -97,3 +97,35 @@ def test_invalid_to_wei_values(value, unit):
 
     with pytest.raises(ValueError):
         from_wei(value, unit)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        1,  # 1000000000000000000 wei
+        0.1,  # 100000000000000000 wei
+        0.01,  # 10000000000000000 wei
+        0.001,  # 1000000000000000 wei
+        0.00000000000000001,  # 10 wei
+        0.000000000000000001,  # 1 wei
+        1.234567891234567891,  # 1234567891234567891 wei
+        0,  # 0 wei
+    ],
+)
+def test_float_ether(value):
+    assert from_wei(to_wei(value, "ether"), "ether") == decimal.Decimal(str(value))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        0.0000000000000000001,  # 0.1 wei
+        0.00000000000000000001,  # 0.01 wei
+        0.000000000000000000001,  # 0.001 wei
+        0.0000000000000000011,  # 1.1 wei
+        0.00000000000000000123456789,  # 1.23456789 wei
+    ],
+)
+def test_invalid_float_ether(value):
+    with pytest.raises(AssertionError):
+        assert from_wei(to_wei(value, "ether"), "ether") == decimal.Decimal(str(value))


### PR DESCRIPTION
## What was wrong?

Issue #102

## How was it fixed?

Add `float` inputs to see that `from_wei(to_wei(value, 'ether'), 'ether') == decimal.Decimal(str(value))` for `float` inputs.
When the decimal of the value is less than 0 Wei, `to_wei` converts it to 0, and the test case gets `AssertionError` because of 0 != 0.0...01.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.theconversation.com/files/438138/original/file-20211216-25-1hu3e65.jpg?ixlib=rb-1.1.0&q=45&auto=format&w=1200&h=900.0&fit=crop)
