### PR TITLE
refactor: Use cached_property to cache the show_debug2

### DIFF
--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -1,7 +1,8 @@
 import contextlib
-import functools
 import logging
-from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Dict, Iterator, Tuple, Type, TypeVar, cast
+
+from cached_property import cached_property
 
 from .toolz import assoc
 
@@ -10,27 +11,12 @@ DEBUG2_LEVEL_NUM = 8
 TLogger = TypeVar("TLogger", bound=logging.Logger)
 
 
-class cached_show_debug2_property:
-    def __init__(self, func: Callable[[TLogger], bool]):
-        # type ignored b/c arg1 expects Callable[..., Any]
-        functools.update_wrapper(self, func)
-        self._func = func
-
-    def __get__(self, obj: Optional[TLogger], cls: Type[logging.Logger]) -> Any:
-        if obj is None:
-            return self
-
-        result = self._func(obj)
-        obj.__dict__[self._func.__name__] = result
-        return result
-
-
 class ExtendedDebugLogger(logging.Logger):
     """
     Logging class that can be used for lower level debug logging.
     """
 
-    @cached_show_debug2_property
+    @cached_property  # type: ignore
     def show_debug2(self) -> bool:
         return self.isEnabledFor(DEBUG2_LEVEL_NUM)
 

--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -1,10 +1,14 @@
 import contextlib
 import logging
+import sys
 from typing import Any, Dict, Iterator, Tuple, Type, TypeVar, cast
 
-from cached_property import cached_property
-
 from .toolz import assoc
+
+if sys.version_info < (3, 8):
+    from cached_property import cached_property
+else:
+    from functools import cached_property
 
 DEBUG2_LEVEL_NUM = 8
 

--- a/newsfragments/232.internal.rst
+++ b/newsfragments/232.internal.rst
@@ -1,0 +1,1 @@
+Update use of ``@cached_property`` for debug2 logging.

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     url="https://github.com/ethereum/eth-utils",
     include_package_data=True,
     install_requires=[
-        "cached-property>=1.5.2,<2",
+        "cached-property>=1.5.2,<2;python_version<'3.8'",
         "eth-hash>=0.3.1,<0.6.0",
         "eth-typing>=3.0.0,<4.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     url="https://github.com/ethereum/eth-utils",
     include_package_data=True,
     install_requires=[
+        "cached-property>=1.5.2,<2",
         "eth-hash>=0.3.1,<0.6.0",
         "eth-typing>=3.0.0,<4.0.0",
         "toolz>0.8.2,<1;implementation_name=='pypy'",


### PR DESCRIPTION
## What was wrong?

Issue #159

## How was it fixed?

Replace `cached_show_debug2_property` with `cached_property`, and add the cached-property package in `install_requires`.
`cached_property` has the [untyped issue](https://github.com/pydanny/cached-property/issues/172), so I add the `# type: ignore`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTEFTlaYRhFLEJHST08mQ-_Vux1n-7LlGVpbQ&usqp=CAU)
