### PR TITLE
Copy `towncrier` types from project template

### DIFF
--- a/newsfragments/235.misc.rst
+++ b/newsfragments/235.misc.rst
@@ -1,0 +1,1 @@
+Add "breaking" newsfragment type

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -15,6 +15,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 * `internal`
 * `removal`
 * `misc`
+* `breaking`
 
 So for example: `123.feature.rst`, `456.bugfix.rst`
 
@@ -23,5 +24,5 @@ then open up the PR first and use the PR number for the newsfragment.
 
 Note that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run
- `towncrier --draft` to get a preview of what the release notes entry
+ `towncrier build --draft` to get a preview of what the release notes entry
  will look like in the final release notes.

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -8,6 +8,7 @@ import pathlib
 import sys
 
 ALLOWED_EXTENSIONS = {
+    '.breaking.rst'
     '.bugfix.rst',
     '.doc.rst',
     '.feature.rst',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
 # Read https://github.com/ethereum/eth-utils/newsfragments/README.md for instructions
-package="eth_utils"
+package = "eth_utils"
 filename = "docs/release_notes.rst"
 directory = "newsfragments"
 underlines = ["-", "~", "^"]
@@ -41,3 +41,8 @@ showcontent = true
 directory = "misc"
 name = "Miscellaneous changes"
 showcontent = false
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes"
+showcontent = true


### PR DESCRIPTION
## What was wrong?

Missing `beaking` type for newsfragments.

## How was it fixed?

Copy `towncrier` related files from the ethereum-python-project-template.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/YgopQGqX2KA/maxresdefault.jpg)
