### PR TITLE
bump docs dependencies & remove unneeded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.9
         environment:
           TOXENV: docs
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.7
         environment:
           TOXENV: docs
   lint:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+
+python:
+  install:
+  - requirements: requirements-docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/newsfragments/239.internal.rst
+++ b/newsfragments/239.internal.rst
@@ -1,0 +1,1 @@
+remove unused docs deps, bump version of remaining

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "hypothesis>=4.43.0,<5.0.0",
         "pytest>=6.2.5,<7",
         "pytest-xdist",
-        "tox==3.14.6",
+        "tox>=3.14.6,<4",
         "types-setuptools",
     ],
     "lint": [

--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,19 @@ from setuptools import (
 
 extras_require = {
     "test": [
-        "hypothesis>=4.43.0,<5.0.0",
-        "pytest>=6.2.5,<7",
+        "hypothesis>=4.43.0",
+        "pytest>=6.2.5",
         "pytest-xdist",
-        "tox>=3.14.6,<4",
+        "tox>=3.14.6",
         "types-setuptools",
     ],
     "lint": [
-        "black>=22",
-        "flake8==3.7.9",
-        "isort>=4.2.15,<5",
+        "black>=22.1.0",
+        "flake8==3.8.3",
+        "isort>=5.11.0",
         "mypy==0.910",
-        "pydocstyle>=5.0.0,<6",
-        "pytest>=6.2.5,<7",
+        "pydocstyle>=5.0.0",
+        "pytest>=6.2.5",
         "types-setuptools",
     ],
     "doc": [
@@ -28,10 +28,10 @@ extras_require = {
         "towncrier>=21,<22",
     ],
     "dev": [
-        "bumpversion>=0.5.3,<1",
-        "pytest-watch>=4.1.0,<5",
-        "wheel>=0.30.0,<1.0.0",
-        "twine>=1.13,<2",
+        "bumpversion>=0.5.3",
+        "pytest-watch>=4.1.0",
+        "wheel>=0.30.0",
+        "twine>=1.13",
         "ipython",
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,9 @@ extras_require = {
         "types-setuptools",
     ],
     "doc": [
-        "Sphinx>=1.6.5,<2",
-        "sphinx_rtd_theme>=0.1.9,<2",
+        "Sphinx>=5.0.0",
+        "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
-        "jinja2>=3.0.0,<3.0.1",
     ],
     "dev": [
         "bumpversion>=0.5.3,<1",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
         "types-setuptools",
     ],
     "doc": [
-        "Sphinx>=5.0.0",
+        "sphinx>=5.0.0",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ basepython=
 extras=
     test
     docs: doc
-whitelist_externals=make
+allowlist_externals=make
 deps=
     eth-hash[pycryptodome]
     typing1: eth-typing<2
@@ -54,4 +54,4 @@ commands=
     black --check --diff {toxinidir}/eth_utils/ {toxinidir}/tests/ {toxinidir}/setup.py {toxinidir}/docs
     pydocstyle {toxinidir}/eth_utils {toxinidir}/tests
     pytest {posargs:tests}/functional-utils/type_inference_tests.py
-whitelist_externals=black
+allowlist_externals=black


### PR DESCRIPTION
## What was wrong?

Docs dependencies can be bumped and unnecessary ones removed

## How was it fixed?

Bumped and removed, plus tox.ini whitelist -> allowlist, and remove all upper-bounds  while I was here.

### To-Do

[//]: # (See: https://eth-utils.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/227306145-8c288757-ea9b-4595-a53e-a95acfe50d95.png)
