### PR TITLE
Added support for custom unit decimals providing

### DIFF
--- a/eth_utils/currency.py
+++ b/eth_utils/currency.py
@@ -36,7 +36,7 @@ MIN_WEI = 0
 MAX_WEI = 2**256 - 1
 
 
-def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
+def from_wei(number: int, unit: Union[str, int]) -> Union[int, decimal.Decimal]:
     """
     Takes a number of wei and converts it to any other ether unit.
     """
@@ -51,7 +51,10 @@ def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
     if number < MIN_WEI or number > MAX_WEI:
         raise ValueError("value must be between 1 and 2**256 - 1")
 
-    unit_value = units[unit.lower()]
+    if is_integer(unit):
+        unit_value = decimal.Decimal(10) ** decimal.Decimal(unit)
+    else:
+        unit_value = units[unit.lower()]
 
     with localcontext() as ctx:
         ctx.prec = 999
@@ -61,7 +64,7 @@ def from_wei(number: int, unit: str) -> Union[int, decimal.Decimal]:
     return result_value
 
 
-def to_wei(number: Union[int, float, str, decimal.Decimal], unit: str) -> int:
+def to_wei(number: Union[int, float, str, decimal.Decimal], unit: Union[str, int]) -> int:
     """
     Takes a number of a unit and converts it to wei.
     """
@@ -80,7 +83,11 @@ def to_wei(number: Union[int, float, str, decimal.Decimal], unit: str) -> int:
         raise TypeError("Unsupported type.  Must be one of integer, float, or string")
 
     s_number = str(number)
-    unit_value = units[unit.lower()]
+
+    if is_integer(unit):
+        unit_value = decimal.Decimal(10) ** decimal.Decimal(unit)
+    else:
+        unit_value = units[unit.lower()]
 
     if d_number == decimal.Decimal(0):
         return 0

--- a/tests/currency-utils/test_currency_tools.py
+++ b/tests/currency-utils/test_currency_tools.py
@@ -119,6 +119,23 @@ def test_float_ether(value):
 @pytest.mark.parametrize(
     "value",
     [
+        1,  # 1000000000000000000 wei
+        0.1,  # 100000000000000000 wei
+        0.01,  # 10000000000000000 wei
+        0.001,  # 1000000000000000 wei
+        0.00000000000000001,  # 10 wei
+        0.000000000000000001,  # 1 wei
+        1.234567891234567891,  # 1234567891234567891 wei
+        0,  # 0 wei
+    ],
+)
+def test_float_usdt(value):
+    assert from_wei(to_wei(value, 6), 6) == decimal.Decimal(str(value))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
         0.0000000000000000001,  # 0.1 wei
         0.00000000000000000001,  # 0.01 wei
         0.000000000000000000001,  # 0.001 wei


### PR DESCRIPTION
### What was wrong?

It's useful to be able to provide the custom unit decimals like `from_wei(123456789, 6)`. This is common practice in typescript API and handy when operating with token with decimals amount e.g. `6` is fetched from blockchain

Related to Issue # https://github.com/web3/web3.js/issues/3169 for web3.js library

### How was it fixed?

Added support for number passing to `from_wei`, `to_wei` that is interpreted as decimals number. 

### Todo:
- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

https://github.com/ethereum/eth-utils/assets/25568730/9517b933-4dec-4e0b-972d-c0c31389beb9
