### PR TITLE
Remove pkg_resources 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib
 lib64
 pip-wheel-metadata
 venv*
+.venv*
 
 # Installer logs
 pip-log.txt

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -1,4 +1,12 @@
-import pkg_resources
+try:
+    from importlib.metadata import version as __version
+except ImportError:
+    # Python 3.7
+    def __version(package_name: str) -> str:  # type: ignore
+        from pkg_resources import get_distribution
+
+        return get_distribution(package_name).version
+
 
 from .abi import (  # noqa: F401
     event_abi_to_log_topic,
@@ -97,4 +105,4 @@ from .types import (  # noqa: F401
     is_tuple,
 )
 
-__version__ = pkg_resources.get_distribution("eth-utils").version
+__version__ = __version("eth-utils")

--- a/newsfragments/242.misc.rst
+++ b/newsfragments/242.misc.rst
@@ -1,0 +1,1 @@
+Use ``importlib`` to replace ``pkg_resources`` (deprecated) in Python >= 3.8.


### PR DESCRIPTION
### What was wrong?

This package is deprecated

Related to Issue #242
Closes #242

### How was it fixed?

Remove `pkg_resources` import above 3.8

### Todo:
- [x] Clean up commit history

- [x] [NOT APPLIED] Add or update documentation related to these changes 

- [x] [NOT APPLIED] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()