### PR TITLE
add build.os to rtd settings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
   install:
     - method: pip

--- a/newsfragments/250.internal.rst
+++ b/newsfragments/250.internal.rst
@@ -1,0 +1,1 @@
+Add ``build.os`` config for readthedocs


### PR DESCRIPTION
### What was wrong?

ReadTheDocs will soon require a `build.os` to be explicitly configured

### How was it fixed?

Added to readthedocs.yml

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-utils/assets/5199899/347fcf20-d82b-413a-b836-ce0c3035c4da)
