### PR TITLE
Separate Network chainId tests from exception cases

### DIFF
--- a/newsfragments/256.internal.rst
+++ b/newsfragments/256.internal.rst
@@ -1,0 +1,1 @@
+Fix and add new test cases for invalid Network ``chain_id``s.

--- a/tests/network-utils/test_network_utils.py
+++ b/tests/network-utils/test_network_utils.py
@@ -14,59 +14,84 @@ from eth_utils import (
     ("chain_id", "expected_name"),
     [
         (1, "Ethereum Mainnet"),
-        (249, None),
         (2, "Expanse Network"),
         (42, "LUKSO Mainnet"),
-        (214, None),
     ],
 )
 def test_network_name_from_chain_id(chain_id, expected_name):
-    if expected_name is not None:
-        result = name_from_chain_id(chain_id)
-        assert result == expected_name
-    else:
-        with pytest.raises(ValidationError) as ex:
-            name_from_chain_id(chain_id)
-        assert "chain_id is not recognized" in str(ex.value)
+    result = name_from_chain_id(chain_id)
+    assert result == expected_name
+
+
+# Use large chainId values that should never exist
+@pytest.mark.parametrize(
+    ("chain_id", "exception"),
+    [
+        (222**222, ValidationError),
+        (333**333, ValidationError),
+        (444**444, ValidationError),
+    ],
+)
+def test_network_name_from_chain_id_with_invalid_chain_id(chain_id, exception):
+    with pytest.raises(exception) as ex:
+        network_from_chain_id(chain_id)
+    assert "chain_id is not recognized" in str(ex.value)
 
 
 @pytest.mark.parametrize(
     ("chain_id", "expected_short_name"),
     [
         (1, "eth"),
-        (249, None),
         (2, "exp"),
         (42, "lukso"),
-        (214, None),
     ],
 )
 def test_short_name_from_chain_id(chain_id, expected_short_name):
-    if expected_short_name is not None:
-        result = short_name_from_chain_id(chain_id)
-        assert isinstance(result, str)
-        assert result == expected_short_name
-    else:
-        with pytest.raises(ValidationError) as ex:
-            short_name_from_chain_id(chain_id)
-        assert "chain_id is not recognized" in str(ex.value)
+    result = short_name_from_chain_id(chain_id)
+    assert isinstance(result, str)
+    assert result == expected_short_name
+
+
+# Use large chainId values that should never exist
+@pytest.mark.parametrize(
+    ("chain_id", "exception"),
+    [
+        (222**222, ValidationError),
+        (333**333, ValidationError),
+        (444**444, ValidationError),
+    ],
+)
+def test_short_name_from_chain_id_with_invalid_chain_id(chain_id, exception):
+    with pytest.raises(exception) as ex:
+        network_from_chain_id(chain_id)
+    assert "chain_id is not recognized" in str(ex.value)
 
 
 @pytest.mark.parametrize(
     ("chain_id", "expected_network"),
     [
         (1, Network(1, "Ethereum Mainnet", "eth", ChainId.ETH)),
-        (249, None),
         (2, Network(2, "Expanse Network", "exp", ChainId.EXP)),
         (42, Network(42, "LUKSO Mainnet", "lukso", ChainId.LUKSO)),
         (43, Network(43, "Darwinia Pangolin Testnet", "pangolin", ChainId.PANGOLIN)),
     ],
 )
 def test_network_from_chain_id(chain_id, expected_network):
-    if expected_network is not None:
-        result = network_from_chain_id(chain_id)
-        assert isinstance(result, Network)
-        assert result == expected_network
-    else:
-        with pytest.raises(ValidationError) as ex:
-            network_from_chain_id(chain_id)
-        assert "chain_id is not recognized" in str(ex.value)
+    result = network_from_chain_id(chain_id)
+    assert isinstance(result, Network)
+    assert result == expected_network
+
+
+# Use large chainId values that should never exist
+@pytest.mark.parametrize(
+    ("chain_id", "exception"),
+    [
+        (222**222, ValidationError),
+        (333**333, ValidationError),
+        (444**444, ValidationError),
+    ],
+)
+def test_network_from_chain_id_with_invalid_chain_id(chain_id, exception):
+    with pytest.raises(exception) as ex:
+        network_from_chain_id(chain_id)
+    assert "chain_id is not recognized" in str(ex.value)

--- a/tests/network-utils/test_network_utils.py
+++ b/tests/network-utils/test_network_utils.py
@@ -23,21 +23,6 @@ def test_network_name_from_chain_id(chain_id, expected_name):
     assert result == expected_name
 
 
-# Use large chainId values that should never exist
-@pytest.mark.parametrize(
-    ("chain_id", "exception"),
-    [
-        (222**222, ValidationError),
-        (333**333, ValidationError),
-        (444**444, ValidationError),
-    ],
-)
-def test_network_name_from_chain_id_with_invalid_chain_id(chain_id, exception):
-    with pytest.raises(exception) as ex:
-        network_from_chain_id(chain_id)
-    assert "chain_id is not recognized" in str(ex.value)
-
-
 @pytest.mark.parametrize(
     ("chain_id", "expected_short_name"),
     [
@@ -50,21 +35,6 @@ def test_short_name_from_chain_id(chain_id, expected_short_name):
     result = short_name_from_chain_id(chain_id)
     assert isinstance(result, str)
     assert result == expected_short_name
-
-
-# Use large chainId values that should never exist
-@pytest.mark.parametrize(
-    ("chain_id", "exception"),
-    [
-        (222**222, ValidationError),
-        (333**333, ValidationError),
-        (444**444, ValidationError),
-    ],
-)
-def test_short_name_from_chain_id_with_invalid_chain_id(chain_id, exception):
-    with pytest.raises(exception) as ex:
-        network_from_chain_id(chain_id)
-    assert "chain_id is not recognized" in str(ex.value)
 
 
 @pytest.mark.parametrize(
@@ -82,16 +52,18 @@ def test_network_from_chain_id(chain_id, expected_network):
     assert result == expected_network
 
 
-# Use large chainId values that should never exist
-@pytest.mark.parametrize(
-    ("chain_id", "exception"),
-    [
-        (222**222, ValidationError),
-        (333**333, ValidationError),
-        (444**444, ValidationError),
-    ],
-)
-def test_network_from_chain_id_with_invalid_chain_id(chain_id, exception):
-    with pytest.raises(exception) as ex:
-        network_from_chain_id(chain_id)
-    assert "chain_id is not recognized" in str(ex.value)
+@pytest.mark.parametrize("invalid_chain_id", (222**222, 333**333, 444**444))
+def test_from_chain_id_utility_methods_with_invalid_chain_id(invalid_chain_id):
+    error_message = f"chain_id is not recognized: {invalid_chain_id}"
+
+    # test network_from_chain_id
+    with pytest.raises(ValidationError, match=error_message):
+        network_from_chain_id(invalid_chain_id)
+
+    # test short_name_from_chain_id
+    with pytest.raises(ValidationError, match=error_message):
+        short_name_from_chain_id(invalid_chain_id)
+
+    # test name_from_chain_id
+    with pytest.raises(ValidationError, match=error_message):
+        name_from_chain_id(invalid_chain_id)


### PR DESCRIPTION
### What was wrong?
Tests failed after networks were updated.

### How was it fixed?
Use large values for invalid `chainId`s that will likely never exist.

### Todo:
- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [X] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/736x/cd/2b/a1/cd2ba1d495e49cec865a9682213a3725.jpg)