### PR TITLE
Improve combomethod type hints

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -4,9 +4,15 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Optional,
+    Generic,
     Type,
     TypeVar,
+    Union,
+)
+
+from typing_extensions import (
+    Concatenate,
+    ParamSpec,
 )
 
 from .types import (
@@ -14,17 +20,18 @@ from .types import (
 )
 
 T = TypeVar("T")
+P = ParamSpec("P")
 
 
-class combomethod:
-    def __init__(self, method: Callable[..., Any]) -> None:
+class combomethod(Generic[P, T]):
+    def __init__(self, method: Callable[Concatenate[Any, P], T]) -> None:
         self.method = method
 
     def __get__(
-        self, obj: Optional[T] = None, objtype: Optional[Type[T]] = None
-    ) -> Callable[..., Any]:
+        self, obj: object = None, objtype: Union[type, None] = None
+    ) -> Callable[P, T]:
         @functools.wraps(self.method)
-        def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        def _wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if obj is not None:
                 return self.method(obj, *args, **kwargs)
             else:

--- a/newsfragments/236.feature.rst
+++ b/newsfragments/236.feature.rst
@@ -1,0 +1,1 @@
+Improve type hints for decorator combomethod.

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "cached-property>=1.5.2,<2;python_version<'3.8'",
+        "typing_extensions",
         "eth-hash>=0.3.1",
         "eth-typing>=3.0.0",
         "toolz>0.8.2;implementation_name=='pypy'",


### PR DESCRIPTION
### What was wrong?

Related to Issue #236 
Closes #236 

### How was it fixed?

This commit adopts the solution from [here](https://github.com/microsoft/pylance-release/issues/3142#issuecomment-1207164159). It uses `ParamSpec` and `Concatenate` added in python3.10. And in order to use this feature minor to 3.10, `typing-extensions` dependency is added in `setup.py` 

### Todo:

- [x] Clean up commit history

- [ ] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-utils/assets/17946284/a626e521-a33b-42db-977d-7c7031a9769c)

