### PR TITLE
`Web3.is_address` no longer requires checksummed addresses

### DIFF
--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -59,12 +59,7 @@ def is_address(value: Any) -> bool:
     """
     Is the given string an address in any of the known formats?
     """
-    if is_hex_address(value):
-        if _is_checksum_formatted(value):
-            return is_checksum_address(value)
-        return True
-
-    if is_binary_address(value):
+    if is_hex_address(value) or is_binary_address(value):
         return True
 
     return False

--- a/newsfragments/265.breaking.rst
+++ b/newsfragments/265.breaking.rst
@@ -1,0 +1,1 @@
+`Web3.is_address` now returns True for non-checksummed addresses.

--- a/tests/address-utils/test_address_utils.py
+++ b/tests/address-utils/test_address_utils.py
@@ -35,8 +35,8 @@ from eth_utils.address import (
         # checksummed - valid
         ("0x5B2063246F2191f18F2675ceDB8b28102e957458", True, True, False),
         (b"0x5B2063246F2191f18F2675ceDB8b28102e957458", False, False, False),
+        ("0x5b2063246F2191f18F2675ceDB8b28102e957458", True, True, False),
         # checksummed - invalid
-        ("0x5b2063246F2191f18F2675ceDB8b28102e957458", False, True, False),
         (b"0x5b2063246F2191f18F2675ceDB8b28102e957458", False, False, False),
         # too short - unprefixed
         ("c6d9d2cd449a754c494264e1809c50e34d64562", False, False, False),


### PR DESCRIPTION
### What was wrong?

Relates to https://github.com/ethereum/web3.py/issues/715
Closes #246 

### How was it fixed?

Removed validation of checksummed addresses from the `Web3.is_address` utility.

### Todo:

- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [X] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="396" alt="Screen Shot 2024-02-20 at 10 51 50 AM" src="https://github.com/ethereum/eth-utils/assets/435903/bcaa5266-8eb7-476c-8986-73b1fd65bef9">

