### PR TITLE
Run `blocklint` via `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
     hooks:
     -   id: mypy
         exclude: 'tests/|fixtures/'
+-   repo: https://github.com/PrincetonUniversity/blocklint
+    rev: v0.2.4
+    hooks:
+    -   id: blocklint
+        exclude: 'docs/Makefile|docs/release_notes.rst|tox.ini|eth_utils/__json'

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ extend-ignore=E203
 max-line-length=88
 per-file-ignores=__init__.py:F401
 
+[blocklint]
+max_issue_threshold=1
+
 [testenv]
 usedevelop=True
 install_command=python -m pip install {opts} {packages}


### PR DESCRIPTION
### What was wrong?

Related to Issue #3119

### How was it fixed?

`blocklint` checks the codebase for any terminology that may be offensive and encourages use of inclusive language.

### Todo:

- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture


