### PR TITLE
remove cached_property if <py38 dependency

### DIFF
--- a/newsfragments/269.internal.rst
+++ b/newsfragments/269.internal.rst
@@ -1,0 +1,1 @@
+Remove ``cached_property`` dependency, as it was only for ``<=py37``

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     url="https://github.com/ethereum/eth-utils",
     include_package_data=True,
     install_requires=[
-        "cached-property>=1.5.2,<2;python_version<'3.8'",
         "eth-hash>=0.3.1",
         "eth-typing>=3.0.0",
         "toolz>0.8.2;implementation_name=='pypy'",


### PR DESCRIPTION
### What was wrong?

`cached_property` is only installed if <=py37, which was dropped a while ago.
Removed it from deps.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-utils/assets/5199899/f31b23f2-e24a-464e-938a-22478c9fc367)
