### PR TITLE
Utilities for Contract ABIs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     rev: v1.5.1
     hooks:
     -   id: mypy
-        exclude: tests/
+        exclude: tests/core
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.5
     hooks:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -53,7 +53,8 @@ If you need to make a commit that skips the ``pre-commit`` checks, you can do so
 
 This library uses type hints, which are enforced by the ``mypy`` tool (part of the
 ``pre-commit`` checks). All new code is required to land with type hints, with the
-exception of code within the ``tests`` directory.
+exception of code within the ``tests/core`` directory. Note that the ``mypy`` checks
+are also run against files within the ``tests/mypy`` directory.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -15,52 +15,21 @@ importing them through the ``curried`` module like so:
 
     >>> from eth_utils.curried import hexstr_if_str
 
-ABI Utils
-~~~~~~~~~
+ABI Utilities
+~~~~~~~~~~~~~
 
-``event_abi_to_log_topic(event_abi)`` -> bytes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Application Binary Interface (ABI) may be used for encoding or decoding
+transactional data. Components of an ABI may include a descriptor of each Function or
+Event in the contract. The following utilities provide convenient methods for parsing
+components of an ABI and encoding function parameters for use in transactions.
 
-Returns the 32 byte log topic for the given event abi.
+For more information about the ABI spec, see the Solidity
+`Contract ABI specification <https://docs.soliditylang.org/en/v0.8.25/abi-spec.html>`_.
 
-.. doctest::
-
-    >>> from eth_utils import event_abi_to_log_topic
-    >>> event_abi_to_log_topic({'type': 'event', 'anonymous': False, 'name': 'MyEvent', 'inputs': []})
-    b'M\xbf\xb6\x8bC\xdd\xdf\xa1+Q\xeb\xe9\x9a\xb8\xfd\xedb\x0f\x9a\n\xc21B\x87\x9aO\x19*\x1byR\xd2'
-
-``event_signature_to_log_topic(event_signature)`` -> bytes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Returns the 32 byte log topic for the given event signature.
-
-.. doctest::
-
-    >>> from eth_utils import event_signature_to_log_topic
-    >>> event_signature_to_log_topic('MyEvent()')
-    b'M\xbf\xb6\x8bC\xdd\xdf\xa1+Q\xeb\xe9\x9a\xb8\xfd\xedb\x0f\x9a\n\xc21B\x87\x9aO\x19*\x1byR\xd2'
-
-``function_abi_to_4byte_selector(function_abi)`` -> bytes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Returns the 4 byte function selector for the given function abi.
-
-.. doctest::
-
-    >>> from eth_utils import function_abi_to_4byte_selector
-    >>> function_abi_to_4byte_selector({'type': 'function', 'name': 'myFunction', 'inputs': [], 'outputs': []})
-    b'\xc3x\n:'
-
-``function_signature_to_4byte_selector(function_signature)`` -> bytes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Returns the 4 byte function selector for the given function signature.
-
-.. doctest::
-
-    >>> from eth_utils import function_signature_to_4byte_selector
-    >>> function_signature_to_4byte_selector('myFunction()')
-    b'\xc3x\n:'
+.. automodule:: eth_utils.abi
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Applicators
 ~~~~~~~~~~~

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -3,10 +3,22 @@ from importlib.metadata import (
 )
 
 from .abi import (
+    abi_to_signature,
+    collapse_if_tuple,
     event_abi_to_log_topic,
     event_signature_to_log_topic,
+    filter_abi_by_name,
+    filter_abi_by_type,
     function_abi_to_4byte_selector,
     function_signature_to_4byte_selector,
+    get_abi_input_names,
+    get_abi_input_types,
+    get_abi_output_names,
+    get_abi_output_types,
+    get_aligned_abi_inputs,
+    get_all_event_abis,
+    get_all_function_abis,
+    get_normalized_abi_inputs,
 )
 from .address import (
     is_address,

--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -1,6 +1,32 @@
+from collections import (
+    abc,
+)
+import copy
+import itertools
+import re
 from typing import (
     Any,
     Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+from eth_typing import (
+    ABI,
+    ABIComponent,
+    ABIElement,
+    ABIEvent,
+    ABIFunction,
+)
+
+from eth_utils.types import (
+    is_list_like,
 )
 
 from .crypto import (
@@ -8,61 +34,754 @@ from .crypto import (
 )
 
 
-def collapse_if_tuple(abi: Dict[str, Any]) -> str:
+def _align_abi_input(
+    arg_abi: ABIComponent, normalized_arg: Any
+) -> Union[Any, Tuple[Any, ...]]:
     """
-    Converts a tuple from a dict to a parenthesized list of its types.
+    Aligns the values of any mapping at any level of nesting in ``normalized_arg``
+    according to the layout of the corresponding abi spec.
+    """
+    tuple_parts = _get_tuple_type_str_and_dims(arg_abi.get("type", ""))
 
-    >>> from eth_utils.abi import collapse_if_tuple
-    >>> collapse_if_tuple(
-    ...     {
-    ...         'components': [
-    ...             {'name': 'anAddress', 'type': 'address'},
-    ...             {'name': 'anInt', 'type': 'uint256'},
-    ...             {'name': 'someBytes', 'type': 'bytes'},
-    ...         ],
-    ...         'type': 'tuple',
-    ...     }
-    ... )
-    '(address,uint256,bytes)'
-    """
-    typ = abi["type"]
-    if not isinstance(typ, str):
+    if tuple_parts is None:
+        # normalized_arg is non-tuple.  Just return value.
+        return normalized_arg
+
+    tuple_prefix, tuple_dims = tuple_parts
+    if tuple_dims is None:
+        # normalized_arg is non-list tuple.  Each sub arg in `normalized_arg` will be
+        # aligned according to its corresponding abi.
+        sub_abis = cast(Iterable[ABIComponent], arg_abi.get("components", []))
+    else:
+        num_dims = tuple_dims.count("[")
+
+        # normalized_arg is list tuple.  A non-list version of its abi will be used to
+        # align each element in `normalized_arg`.
+        new_abi = copy.copy(arg_abi)
+        new_abi["type"] = tuple_prefix + "[]" * (num_dims - 1)
+
+        sub_abis = itertools.repeat(new_abi)
+
+    if isinstance(normalized_arg, abc.Mapping):
+        # normalized_arg is mapping.  Align values according to abi order.
+        aligned_arg = tuple(normalized_arg[abi["name"]] for abi in sub_abis)
+    else:
+        aligned_arg = normalized_arg
+
+    if not is_list_like(aligned_arg):
         raise TypeError(
-            f"The 'type' must be a string, but got {repr(typ)} of type {type(typ)}"
+            f'Expected non-string sequence for "{arg_abi.get("type")}" '
+            f"component type: got {aligned_arg}"
         )
-    elif not typ.startswith("tuple"):
-        return typ
+
+    # convert NamedTuple to regular tuple
+    typing = tuple if isinstance(aligned_arg, tuple) else type(aligned_arg)
+
+    return typing(
+        _align_abi_input(sub_abi, sub_arg)
+        for sub_abi, sub_arg in zip(sub_abis, aligned_arg)
+    )
+
+
+def _get_tuple_type_str_and_dims(s: str) -> Optional[Tuple[str, Optional[str]]]:
+    """
+    Takes a JSON ABI type string.  For tuple type strings, returns the separated
+    prefix and array dimension parts.  For all other strings, returns ``None``.
+    """
+    tuple_type_str_re = "^(tuple)((\\[([1-9]\\d*\b)?])*)??$"
+    match = re.compile(tuple_type_str_re).match(s)
+
+    if match is not None:
+        tuple_prefix = match.group(1)
+        tuple_dims = match.group(2)
+
+        return tuple_prefix, tuple_dims
+
+    return None
+
+
+def _raise_if_not_function_abi(abi_element: ABIElement) -> None:
+    if abi_element["type"] != "function":
+        raise ValueError(
+            f"Outputs only supported for ABI type `function`. Provided"
+            f" ABI type was `{abi_element.get('type')}` and outputs were "
+            f"`{abi_element.get('outputs')}`."
+        )
+
+
+def _raise_if_fallback_or_receive_abi(abi_element: ABIElement) -> None:
+    if abi_element["type"] == "fallback" or abi_element["type"] == "receive":
+        raise ValueError(
+            f"Inputs not supported for function types `fallback` or `receive`. Provided"
+            f" ABI type was `{abi_element.get('type')}` with inputs "
+            f"`{abi_element.get('inputs')}`."
+        )
+
+
+def collapse_if_tuple(abi: Union[ABIComponent, Dict[str, Any], str]) -> str:
+    """
+    Extract argument types from a function or event ABI parameter.
+
+    With tuple argument types, return a Tuple of each type.
+    Returns the param if `abi` is an instance of str or another non-tuple
+    type.
+
+    :param abi: A Function or Event ABI component or a string with type info.
+    :type abi: `Union[ABIComponent, Dict[str, Any], str]`
+    :return: Type(s) for the function or event ABI param.
+    :rtype: `str`
+
+    .. doctest::
+
+        >>> from eth_utils.abi import collapse_if_tuple
+        >>> abi = {
+        ...   'components': [
+        ...     {'name': 'anAddress', 'type': 'address'},
+        ...     {'name': 'anInt', 'type': 'uint256'},
+        ...     {'name': 'someBytes', 'type': 'bytes'},
+        ...   ],
+        ...   'type': 'tuple',
+        ... }
+        >>> collapse_if_tuple(abi)
+        '(address,uint256,bytes)'
+    """
+    if isinstance(abi, str):
+        return abi
+
+    element_type = abi.get("type")
+    if not isinstance(element_type, str):
+        raise TypeError(
+            f"The 'type' must be a string, but got {repr(element_type)} of type "
+            f"{type(element_type)}"
+        )
+    elif not element_type.startswith("tuple"):
+        return element_type
 
     delimited = ",".join(collapse_if_tuple(c) for c in abi["components"])
     # Whatever comes after "tuple" is the array dims. The ABI spec states that
     # this will have the form "", "[]", or "[k]".
-    array_dim = typ[5:]
+    array_dim = element_type[5:]
     collapsed = f"({delimited}){array_dim}"
 
     return collapsed
 
 
-def _abi_to_signature(abi: Dict[str, Any]) -> str:
-    fn_input_types = ",".join(
-        [collapse_if_tuple(abi_input) for abi_input in abi.get("inputs", [])]
+def abi_to_signature(abi_element: ABIElement) -> str:
+    """
+    Returns a string signature representation of the function or event ABI
+    and arguments.
+
+    Signatures consist of the name followed by a list of arguments.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :return: Stringified ABI signature
+    :rtype: `str`
+
+    .. doctest::
+
+        >>> from eth_utils import abi_to_signature
+        >>> abi_element = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> abi_to_signature(abi_element)
+        'f(uint256)'
+    """
+    signature = "{name}({input_types})"
+
+    abi_type = str(abi_element.get("type", ""))
+    if abi_type == "fallback" or abi_type == "receive":
+        return signature.format(name=abi_type, input_types="")
+
+    if abi_type == "constructor":
+        fn_name = abi_type
+    else:
+        fn_name = str(abi_element.get("name", abi_type))
+
+    return signature.format(
+        name=fn_name, input_types=",".join(get_abi_input_types(abi_element))
     )
-    function_signature = f"{abi['name']}({fn_input_types})"
-    return function_signature
 
 
-def function_signature_to_4byte_selector(event_signature: str) -> bytes:
-    return keccak(text=event_signature.replace(" ", ""))[:4]
+def filter_abi_by_name(abi_name: str, contract_abi: ABI) -> Sequence[ABIElement]:
+    """
+    Get one or more function and event ABIs by name.
+
+    :param abi_name: Name of the function, event or error.
+    :type abi_name: `str`
+    :param contract_abi: Contract ABI.
+    :type contract_abi: `ABI`
+    :return: Function or event ABIs with matching name.
+    :rtype: `Sequence[ABIElement]`
+
+    .. doctest::
+
+            >>> from eth_utils.abi import filter_abi_by_name
+            >>> abi = [
+            ...     {
+            ...         "constant": False,
+            ...         "inputs": [],
+            ...         "name": "func_1",
+            ...         "outputs": [],
+            ...         "type": "function",
+            ...     },
+            ...     {
+            ...         "constant": False,
+            ...         "inputs": [
+            ...             {"name": "a", "type": "uint256"},
+            ...         ],
+            ...         "name": "func_2",
+            ...         "outputs": [],
+            ...         "type": "function",
+            ...     },
+            ...     {
+            ...         "constant": False,
+            ...         "inputs": [
+            ...             {"name": "a", "type": "uint256"},
+            ...             {"name": "b", "type": "uint256"},
+            ...         ],
+            ...         "name": "func_3",
+            ...         "outputs": [],
+            ...         "type": "function",
+            ...     },
+            ...     {
+            ...         "constant": False,
+            ...         "inputs": [
+            ...             {"name": "a", "type": "uint256"},
+            ...             {"name": "b", "type": "uint256"},
+            ...             {"name": "c", "type": "uint256"},
+            ...         ],
+            ...         "name": "func_4",
+            ...         "outputs": [],
+            ...         "type": "function",
+            ...     },
+            ... ]
+            >>> filter_abi_by_name("func_1", abi)
+            [{'constant': False, 'inputs': [], 'name': 'func_1', 'outputs': [], \
+'type': 'function'}]
+    """
+    return [
+        abi
+        for abi in contract_abi
+        if (
+            (
+                abi["type"] == "function"
+                or abi["type"] == "event"
+                or abi["type"] == "error"
+            )
+            and abi["name"] == abi_name
+        )
+    ]
 
 
-def function_abi_to_4byte_selector(function_abi: Dict[str, Any]) -> bytes:
-    function_signature = _abi_to_signature(function_abi)
+def filter_abi_by_type(abi_type: str, contract_abi: ABI) -> Sequence[ABIElement]:
+    """
+    Return a list of each ``ABIElement`` that is of type ``abi_type``.
+
+    :param abi_type: Type of ABI element to filter by.
+    :type abi_type: `str`
+    :param contract_abi: Contract ABI.
+    :type contract_abi: `ABI`
+    :return: List of ABI elements of the specified type.
+    :rtype: `Sequence[ABIElement]`
+
+    .. doctest::
+
+        >>> from eth_utils import filter_abi_by_type
+        >>> abi = [
+        ...   {"type": "function", "name": "myFunction", "inputs": [], "outputs": []},
+        ...   {"type": "function", "name": "myFunction2", "inputs": [], "outputs": []},
+        ...   {"type": "event", "name": "MyEvent", "inputs": []}
+        ... ]
+        >>> filter_abi_by_type("function", abi)
+        [{'type': 'function', 'name': 'myFunction', 'inputs': [], 'outputs': []}, \
+{'type': 'function', 'name': 'myFunction2', 'inputs': [], 'outputs': []}]
+    """
+    return [abi for abi in contract_abi if abi["type"] == abi_type]
+
+
+def get_all_function_abis(contract_abi: ABI) -> Sequence[ABIFunction]:
+    """
+    Return interfaces for each function in the contract ABI.
+
+    :param contract_abi: Contract ABI.
+    :type contract_abi: `ABI`
+    :return: List of ABIs for each function interface.
+    :rtype: `Sequence[ABIFunction]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_all_function_abis
+        >>> contract_abi = [
+        ...   {"type": "function", "name": "myFunction", "inputs": [], "outputs": []},
+        ...   {"type": "function", "name": "myFunction2", "inputs": [], "outputs": []},
+        ...   {"type": "event", "name": "MyEvent", "inputs": []}
+        ... ]
+        >>> get_all_function_abis(contract_abi)
+        [{'type': 'function', 'name': 'myFunction', 'inputs': [], 'outputs': []}, \
+{'type': 'function', 'name': 'myFunction2', 'inputs': [], 'outputs': []}]
+    """
+    return [
+        cast(ABIFunction, function_abi)
+        for function_abi in filter_abi_by_type("function", contract_abi)
+    ]
+
+
+def get_all_event_abis(contract_abi: ABI) -> Sequence[ABIEvent]:
+    """
+    Return interfaces for each event in the contract ABI.
+
+    :param contract_abi: Contract ABI.
+    :type contract_abi: `ABI`
+    :return: List of ABIs for each event interface.
+    :rtype: `Sequence[ABIEvent]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_all_event_abis
+        >>> contract_abi = [
+        ...   {"type": "function", "name": "myFunction", "inputs": [], "outputs": []},
+        ...   {"type": "function", "name": "myFunction2", "inputs": [], "outputs": []},
+        ...   {"type": "event", "name": "MyEvent", "inputs": []}
+        ... ]
+        >>> get_all_event_abis(contract_abi)
+        [{'type': 'event', 'name': 'MyEvent', 'inputs': []}]
+    """
+    return [
+        cast(ABIEvent, event) for event in filter_abi_by_type("event", contract_abi)
+    ]
+
+
+def get_normalized_abi_inputs(
+    abi_element: ABIElement,
+    *args: Optional[Sequence[Any]],
+    **kwargs: Optional[Dict[str, Any]],
+) -> Tuple[Any, ...]:
+    r"""
+    Flattens positional args (``args``) and keyword args (``kwargs``) into a Tuple and
+    uses the ``abi_element`` for validation.
+
+    Checks to ensure that the correct number of args were given, no duplicate args were
+    given, and no unknown args were given.  Returns a list of argument values aligned
+    to the order of inputs defined in ``abi_element``.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :param args: Positional arguments for the function.
+    :type args: `Optional[Sequence[Any]]`
+    :param kwargs: Keyword arguments for the function.
+    :type kwargs: `Optional[Dict[str, Any]]`
+    :return: Arguments list.
+    :rtype: `Tuple[Any, ...]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_normalized_abi_inputs
+        >>> abi = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 'name',
+        ...       'type': 'string'
+        ...     },
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     },
+        ...     {
+        ...       'name': 't',
+        ...       'components': [
+        ...         {'name': 'anAddress', 'type': 'address'},
+        ...         {'name': 'anInt', 'type': 'uint256'},
+        ...         {'name': 'someBytes', 'type': 'bytes'},
+        ...       ],
+        ...       'type': 'tuple'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> get_normalized_abi_inputs(
+        ...   abi, *('myName', 123), **{'t': ('0x1', 1, b'\x01')}
+        ... )
+        ('myName', 123, ('0x1', 1, b'\x01'))
+    """
+    _raise_if_fallback_or_receive_abi(abi_element)
+
+    function_inputs = cast(Sequence[ABIComponent], abi_element.get("inputs", []))
+    if len(args) + len(kwargs) != len(function_inputs):
+        raise TypeError(
+            f"Incorrect argument count. Expected '{len(function_inputs)}'"
+            f", got '{len(args) + len(kwargs)}'."
+        )
+
+    # If no keyword args were given, we don't need to align them
+    if not kwargs:
+        return cast(Tuple[Any, ...], args)
+
+    kwarg_names = set(kwargs.keys())
+    sorted_arg_names = tuple(arg_abi["name"] for arg_abi in function_inputs)
+    args_as_kwargs = dict(zip(sorted_arg_names, args))
+
+    # Check for duplicate args
+    duplicate_args = kwarg_names.intersection(args_as_kwargs.keys())
+    if duplicate_args:
+        raise TypeError(
+            f"{abi_element.get('name')}() got multiple values for argument(s) "
+            f"'{', '.join(duplicate_args)}'."
+        )
+
+    # Check for unknown args
+    # Arg names sorted to raise consistent error messages
+    unknown_args = tuple(sorted(kwarg_names.difference(sorted_arg_names)))
+    if unknown_args:
+        message = "{} got unexpected keyword argument(s) '{}'."
+        if abi_element.get("name"):
+            raise TypeError(
+                message.format(f"{abi_element.get('name')}()", ", ".join(unknown_args))
+            )
+        raise TypeError(
+            message.format(
+                f"Type: '{abi_element.get('type')}'", ", ".join(unknown_args)
+            )
+        )
+
+    # Sort args according to their position in the ABI and unzip them from their
+    # names
+    sorted_args = tuple(
+        zip(
+            *sorted(
+                itertools.chain(kwargs.items(), args_as_kwargs.items()),
+                key=lambda kv: sorted_arg_names.index(kv[0]),
+            )
+        )
+    )
+
+    if len(sorted_args) > 0:
+        return tuple(sorted_args[1])
+    else:
+        return tuple()
+
+
+def get_aligned_abi_inputs(
+    abi_element: ABIElement,
+    normalized_args: Union[Tuple[Any, ...], Mapping[Any, Any]],
+) -> Tuple[Tuple[str, ...], Tuple[Any, ...]]:
+    """
+    Returns a pair of nested Tuples containing a list of types and a list of input
+    values sorted by the order specified by the ``abi``.
+
+    ``normalized_args`` can be obtained by using
+    :py:meth:`eth_utils.abi.get_normalized_abi_inputs`, which returns nested mappings
+    or sequences corresponding to tuple-encoded values in ``abi``.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :param normalized_args: Normalized arguments for the function.
+    :type normalized_args: `Union[Tuple[Any, ...], Mapping[Any, Any]]`
+    :return: Tuple of types and aligned arguments.
+    :rtype: `Tuple[Tuple[Any, ...], Tuple[Any, ...]]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_aligned_abi_inputs
+        >>> abi = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 'name',
+        ...       'type': 'string'
+        ...     },
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> get_aligned_abi_inputs(abi, ('myName', 123))
+        (('string', 'uint256'), ('myName', 123))
+    """
+    _raise_if_fallback_or_receive_abi(abi_element)
+
+    abi_element_inputs = cast(Sequence[ABIComponent], abi_element.get("inputs", []))
+    if isinstance(normalized_args, abc.Mapping):
+        # `args` is mapping.  Align values according to abi order.
+        normalized_args = tuple(
+            normalized_args[abi["name"]] for abi in abi_element_inputs
+        )
+
+    return (
+        tuple(collapse_if_tuple(abi) for abi in abi_element_inputs),
+        type(normalized_args)(
+            _align_abi_input(abi, arg)
+            for abi, arg in zip(abi_element_inputs, normalized_args)
+        ),
+    )
+
+
+def get_abi_input_names(abi_element: ABIElement) -> List[str]:
+    """
+    Return names for each input from the function or event ABI.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :return: Names for each input in the function or event ABI.
+    :rtype: `List[str]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_abi_input_names
+        >>> abi = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> get_abi_input_names(abi)
+        ['s']
+    """
+    _raise_if_fallback_or_receive_abi(abi_element)
+    return [
+        arg["name"]
+        for arg in cast(Sequence[ABIComponent], abi_element.get("inputs", []))
+    ]
+
+
+def get_abi_input_types(abi_element: ABIElement) -> List[str]:
+    """
+    Return types for each input from the function or event ABI.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :return: Types for each input in the function or event ABI.
+    :rtype: `List[str]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_abi_input_types
+        >>> abi = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> get_abi_input_types(abi)
+        ['uint256']
+    """
+    _raise_if_fallback_or_receive_abi(abi_element)
+    return [
+        collapse_if_tuple(arg)
+        for arg in cast(Sequence[ABIComponent], abi_element.get("inputs", []))
+    ]
+
+
+def get_abi_output_names(abi_element: ABIElement) -> List[str]:
+    """
+    Return names for each output from the ABI element.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :return: Names for each function output in the function ABI.
+    :rtype: `List[str]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_abi_output_names
+        >>> abi = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [
+        ...     {
+        ...       'name': 'name',
+        ...       'type': 'string'
+        ...     },
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> get_abi_output_names(abi)
+        ['name', 's']
+    """
+    _raise_if_not_function_abi(abi_element)
+    return [
+        arg["name"]
+        for arg in cast(Sequence[ABIComponent], abi_element.get("outputs", []))
+    ]
+
+
+def get_abi_output_types(abi_element: ABIElement) -> List[str]:
+    """
+    Return types for each output from the function ABI.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :return: Types for each function output in the function ABI.
+    :rtype: `List[str]`
+
+    .. doctest::
+
+        >>> from eth_utils import get_abi_output_types
+        >>> abi = {
+        ...   'constant': False,
+        ...   'inputs': [
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'name': 'f',
+        ...   'outputs': [
+        ...     {
+        ...       'name': 'name',
+        ...       'type': 'string'
+        ...     },
+        ...     {
+        ...       'name': 's',
+        ...       'type': 'uint256'
+        ...     }
+        ...   ],
+        ...   'payable': False,
+        ...   'stateMutability': 'nonpayable',
+        ...   'type': 'function'
+        ... }
+        >>> get_abi_output_types(abi)
+        ['string', 'uint256']
+
+    """
+    _raise_if_not_function_abi(abi_element)
+    return [
+        collapse_if_tuple(arg)
+        for arg in cast(Sequence[ABIComponent], abi_element.get("outputs", []))
+    ]
+
+
+def function_signature_to_4byte_selector(function_signature: str) -> bytes:
+    r"""
+    Return the 4-byte function selector from a function signature string.
+
+    :param function_signature: String representation of the function name and arguments.
+    :type function_signature: `str`
+    :return: 4-byte function selector.
+    :rtype: `bytes`
+
+    .. doctest::
+
+        >>> from eth_utils import function_signature_to_4byte_selector
+        >>> function_signature_to_4byte_selector('myFunction()')
+        b'\xc3x\n:'
+    """
+    return keccak(text=function_signature.replace(" ", ""))[:4]
+
+
+def function_abi_to_4byte_selector(abi_element: ABIElement) -> bytes:
+    r"""
+    Return the 4-byte function signature of the provided function ABI.
+
+    :param abi_element: ABI element.
+    :type abi_element: `ABIElement`
+    :return: 4-byte function signature.
+    :rtype: `bytes`
+
+    .. doctest::
+
+        >>> from eth_utils import function_abi_to_4byte_selector
+        >>> abi_element = {
+        ...   'type': 'function',
+        ...   'name': 'myFunction',
+        ...   'inputs': [],
+        ...   'outputs': []
+        ... }
+        >>> function_abi_to_4byte_selector(abi_element)
+        b'\xc3x\n:'
+    """
+    function_signature = abi_to_signature(abi_element)
     return function_signature_to_4byte_selector(function_signature)
 
 
 def event_signature_to_log_topic(event_signature: str) -> bytes:
+    r"""
+    Return the 32-byte keccak signature of the log topic for an event signature.
+
+    :param event_signature: String representation of the event name and arguments.
+    :type event_signature: `str`
+    :return: Log topic bytes.
+    :rtype: `bytes`
+
+    .. doctest::
+
+        >>> from eth_utils import event_signature_to_log_topic
+        >>> event_signature_to_log_topic('MyEvent()')
+        b'M\xbf\xb6\x8bC\xdd\xdf\xa1+Q\xeb\xe9\x9a\xb8\xfd\xedb\x0f\x9a\n\xc21B\x87\x9aO\x19*\x1byR\xd2'
+    """
     return keccak(text=event_signature.replace(" ", ""))
 
 
-def event_abi_to_log_topic(event_abi: Dict[str, Any]) -> bytes:
-    event_signature = _abi_to_signature(event_abi)
+def event_abi_to_log_topic(event_abi: ABIEvent) -> bytes:
+    r"""
+    Return the 32-byte keccak signature of the log topic from an event ABI.
+
+    :param event_abi: Event ABI.
+    :type event_abi: `ABIEvent`
+    :return: Log topic bytes.
+    :rtype: `bytes`
+
+    .. doctest::
+
+        >>> from eth_utils import event_abi_to_log_topic
+        >>> abi = {
+        ...   'type': 'event',
+        ...   'anonymous': False,
+        ...   'name': 'MyEvent',
+        ...   'inputs': []
+        ... }
+        >>> event_abi_to_log_topic(abi)
+        b'M\xbf\xb6\x8bC\xdd\xdf\xa1+Q\xeb\xe9\x9a\xb8\xfd\xedb\x0f\x9a\n\xc21B\x87\x9aO\x19*\x1byR\xd2'
+    """
+    event_signature = abi_to_signature(event_abi)
     return event_signature_to_log_topic(event_signature)

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -19,6 +19,7 @@ from eth_utils import (
     HasLoggerMeta,
     Network,
     ValidationError,
+    abi_to_signature,
     add_0x_prefix,
     apply_formatter_at_index,
     apply_formatter_if as non_curried_apply_formatter_if,
@@ -30,6 +31,7 @@ from eth_utils import (
     apply_to_return_value,
     big_endian_to_int,
     clamp,
+    collapse_if_tuple,
     combine_argument_formatters,
     combomethod,
     decode_hex,
@@ -37,12 +39,22 @@ from eth_utils import (
     encode_hex,
     event_abi_to_log_topic,
     event_signature_to_log_topic,
+    filter_abi_by_name,
+    filter_abi_by_type,
     flatten_return,
     from_wei,
     function_abi_to_4byte_selector,
     function_signature_to_4byte_selector,
+    get_abi_input_names,
+    get_abi_input_types,
+    get_abi_output_names,
+    get_abi_output_types,
+    get_aligned_abi_inputs,
+    get_all_event_abis,
+    get_all_function_abis,
     get_extended_debug_logger,
     get_logger,
+    get_normalized_abi_inputs,
     hexstr_if_str as non_curried_hexstr_if_str,
     humanize_bytes,
     humanize_hash,
@@ -241,8 +253,12 @@ apply_formatters_to_dict = curry(non_curried_apply_formatters_to_dict)  # noqa: 
 apply_formatters_to_sequence = curry(apply_formatters_to_sequence)
 apply_key_map = curry(apply_key_map)
 apply_one_of_formatters = curry(non_curried_apply_one_of_formatters)  # noqa: F811
+filter_abi_by_name = curry(filter_abi_by_name)
+filter_abi_by_type = curry(filter_abi_by_type)
 from_wei = curry(from_wei)
+get_aligned_abi_inputs = curry(get_aligned_abi_inputs)
 get_logger = curry(get_logger)
+get_normalized_abi_inputs = curry(get_normalized_abi_inputs)
 hexstr_if_str = curry(non_curried_hexstr_if_str)  # noqa: F811
 is_same_address = curry(is_same_address)
 text_if_str = curry(non_curried_text_if_str)  # noqa: F811

--- a/newsfragments/271.breaking.rst
+++ b/newsfragments/271.breaking.rst
@@ -1,0 +1,1 @@
+Updates to the latest ``eth-typing`` to use new ``ABI`` types for improved type checking in existing ``ABI`` utility functions.

--- a/newsfragments/271.feature.rst
+++ b/newsfragments/271.feature.rst
@@ -1,0 +1,1 @@
+Contract Application Binary Interface (ABI) utilities to obtain type and value information for `functions` and `events`.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-hash>=0.3.1",
-        "eth-typing>=3.0.0",
+        "eth-typing>=5.0.0b1",
+        "hexbytes>=1.0.0",
         "toolz>0.8.2;implementation_name=='pypy'",
         "cytoolz>=0.10.1;implementation_name=='cpython'",
     ],

--- a/tests/core/abi-utils/test_abi_utils.py
+++ b/tests/core/abi-utils/test_abi_utils.py
@@ -1,99 +1,521 @@
 import pytest
+import re
+from typing import (
+    Any,
+    Dict,
+    Mapping,
+    NamedTuple,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from eth_typing import (
+    ABI,
+    ABIComponent,
+    ABIComponentIndexed,
+    ABIConstructor,
+    ABIElement,
+    ABIError,
+    ABIEvent,
+    ABIFallback,
+    ABIFunction,
+    ABIReceive,
+    HexStr,
+)
 
 from eth_utils.abi import (
-    _abi_to_signature,
+    abi_to_signature,
+    collapse_if_tuple,
     event_abi_to_log_topic,
     event_signature_to_log_topic,
+    filter_abi_by_name,
+    filter_abi_by_type,
     function_abi_to_4byte_selector,
     function_signature_to_4byte_selector,
+    get_abi_input_names,
+    get_abi_input_types,
+    get_abi_output_names,
+    get_abi_output_types,
+    get_aligned_abi_inputs,
+    get_all_event_abis,
+    get_all_function_abis,
+    get_normalized_abi_inputs,
 )
 from eth_utils.hexadecimal import (
     encode_hex,
 )
 
-FN_ABI_A = {"name": "tokenLaunched", "type": "function", "inputs": []}
-FN_ABI_B = {"name": "CEILING", "type": "function", "inputs": []}
-FN_ABI_C = {
-    "name": "Registrar",
-    "type": "function",
+ABI_FUNCTION_NO_NAME = ABIFunction({"type": "function"})  # type: ignore
+
+ABI_FUNCTION_NO_INPUTS = ABIFunction({"name": "noInputs", "type": "function"})
+
+ABI_FUNCTION_TOKEN_LAUNCHED = ABIFunction(
+    {"name": "tokenLaunched", "type": "function", "inputs": []}
+)
+ABI_FUNCTION_TOKEN_LAUNCHED_WITH_INPUT = ABIFunction(
+    {
+        "name": "tokenLaunched",
+        "type": "function",
+        "inputs": [{"type": "int256", "name": "value"}],
+    }
+)
+
+ABI_FUNCTION_CEILING = ABIFunction(
+    {"name": "CEILING", "type": "function", "inputs": []}
+)
+
+ABI_FUNCTION_REGISTRAR = ABIFunction(
+    {
+        "name": "Registrar",
+        "type": "function",
+        "inputs": [
+            {"type": "address", "name": "a"},
+            {"type": "bytes32", "name": "b"},
+            {"type": "address", "name": "c"},
+        ],
+    }
+)
+
+ABI_FUNCTION_FOUR_NAMED_ARGS = ABIFunction(
+    {
+        "constant": False,
+        "inputs": [
+            {"name": "a", "type": "int256"},
+            {"name": "b", "type": "int256"},
+            {"name": "c", "type": "int256"},
+            {"name": "d", "type": "int256"},
+        ],
+        "name": "fourNamedArgs",
+        "outputs": [],
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_THREE_NAMED_ARGS_DUPLICATE = ABIFunction(
+    {
+        "constant": False,
+        "inputs": [
+            {"name": "b", "type": "int256"},
+            {"name": "b", "type": "int256"},
+            {"name": "a", "type": "int256"},
+        ],
+        "name": "threeNamedArgs",
+        "outputs": [],
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_TWO_NAMED_ARGS = ABIFunction(
+    {
+        "type": "function",
+        "name": "FnMultiArg",
+        "inputs": [
+            {"name": "arg0", "type": "uint256"},
+            {"name": "arg1", "type": "uint256"},
+        ],
+        "outputs": [
+            {"name": "arg0", "type": "uint256"},
+            {"name": "arg1", "type": "uint256"},
+        ],
+    }
+)
+
+ABI_FUNCTION_MULTI_TYPED_ARGS = ABIFunction(
+    {
+        "type": "function",
+        "name": "FnMultiTypedArg",
+        "inputs": [
+            {"name": "arg0", "type": "uint256"},
+            {"name": "arg1", "type": "bytes32"},
+        ],
+        "outputs": [
+            {"name": "arg0", "type": "uint256"},
+            {"name": "arg1", "type": "bytes32"},
+        ],
+    }
+)
+
+ABI_FUNCTION_TWO_UNNAMED_ARGS = ABIFunction(
+    {
+        "constant": False,
+        "inputs": [
+            {"name": "", "type": "int256"},
+            {"name": "", "type": "int256"},
+        ],
+        "name": "twoUnnamedArgs",
+        "outputs": [],
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_SINGLE_ARG = ABIFunction(
+    {
+        "type": "function",
+        "name": "FnSingleArg",
+        "inputs": [{"name": "arg0", "type": "uint256"}],
+        "outputs": [{"name": "arg0", "type": "uint256"}],
+    }
+)
+
+ABI_FUNCTION_ADD = ABIFunction(
+    {
+        "constant": False,
+        "inputs": [
+            {"name": "x", "type": "uint256"},
+            {"name": "y", "type": "uint256"},
+        ],
+        "name": "add",
+        "outputs": [{"name": "sum", "type": "uint256"}],
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_TUPLE_INPUT_WITH_OUTPUTS = ABIFunction(
+    {
+        "inputs": [
+            {
+                "components": [{"name": "x", "type": "uint256"}],
+                "type": "tuple",
+                "name": "aTuple",
+            }
+        ],
+        "name": "singletonTupleInput",
+        "outputs": [{"name": "y", "type": "uint256"}],
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_TUPLE_INPUT_WITH_MULTI_TYPE_OUTPUTS = ABIFunction(
+    {
+        "inputs": [
+            {
+                "components": [{"name": "x", "type": "uint256"}],
+                "type": "tuple",
+                "name": "aTuple",
+            }
+        ],
+        "name": "singletonTupleInput",
+        "outputs": [
+            {"name": "anAddress", "type": "address"},
+            {"name": "anInt", "type": "uint256"},
+            {"name": "someBytes", "type": "bytes"},
+        ],
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_NESTED_TUPLE_INPUTS = ABIFunction(
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"name": "anAddress", "type": "address"},
+                    {"name": "anInt", "type": "uint256"},
+                    {"name": "someBytes", "type": "bytes"},
+                    {
+                        "name": "aTuple",
+                        "type": "tuple",
+                        "components": [
+                            {"name": "anAddress", "type": "address"},
+                            {"name": "anInt", "type": "uint256"},
+                            {"name": "someBytes", "type": "bytes"},
+                        ],
+                    },
+                ],
+                "type": "tuple",
+                "name": "aTuple",
+            }
+        ],
+        "name": "nestedTupleInputs",
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_ZERO_TUPLE_INPUT = ABIFunction(
+    {
+        "inputs": [{"components": [], "type": "tuple", "name": "zroTuple"}],
+        "name": "zeroTupleInput",
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_SINGLETON_TUPLE_INPUT = ABIFunction(
+    {
+        "inputs": [
+            {
+                "components": [{"name": "anAddress", "type": "address"}],
+                "type": "tuple",
+                "name": "aTuple",
+            }
+        ],
+        "name": "singletonTupleInput",
+        "type": "function",
+    }
+)
+
+ABI_FUNCTION_ARRAY_OF_TUPLES = ABIFunction(
+    {
+        "name": "tupleArrayInput",
+        "type": "function",
+        "inputs": [
+            {
+                "name": "tupleArray",
+                "type": "tuple[]",
+                "components": [
+                    {"name": "anAddress", "type": "address"},
+                    {"name": "anInt", "type": "uint256"},
+                    {"name": "someBytes", "type": "bytes"},
+                ],
+            }
+        ],
+    }
+)
+
+ABI_FUNCTION_FIXED_ARRAY_OF_TUPLES = ABIFunction(
+    {
+        "name": "tupleFixedArrayInput",
+        "type": "function",
+        "inputs": [
+            {
+                "name": "tupleArrayFixed",
+                "type": "tuple[5]",
+                "components": [
+                    {"name": "anAddress", "type": "address"},
+                    {"name": "anInt", "type": "uint256"},
+                    {"name": "someBytes", "type": "bytes"},
+                ],
+            }
+        ],
+    }
+)
+
+ABI_FUNCTION_MULTI_TUPLE_INPUTS = ABIFunction(
+    {
+        "constant": False,
+        "inputs": [
+            {
+                "components": [
+                    {"name": "a", "type": "uint256"},
+                    {"name": "b", "type": "uint256[]"},
+                    {
+                        "components": [
+                            {"name": "x", "type": "uint256"},
+                            {"name": "y", "type": "uint256"},
+                        ],
+                        "name": "c",
+                        "type": "tuple[]",
+                    },
+                ],
+                "name": "s",
+                "type": "tuple",
+            },
+            {
+                "components": [
+                    {"name": "x", "type": "uint256"},
+                    {"name": "y", "type": "uint256"},
+                ],
+                "name": "t",
+                "type": "tuple",
+            },
+            {"name": "a", "type": "uint256"},
+            {
+                "components": [
+                    {"name": "x", "type": "uint256"},
+                    {"name": "y", "type": "uint256"},
+                ],
+                "name": "b",
+                "type": "tuple[][]",
+            },
+        ],
+        "name": "multiTupleInputs",
+        "outputs": [],
+        "payable": False,
+        "stateMutability": "nonpayable",
+        "type": "function",
+    }
+)
+
+ABI_CONSTRUCTOR = ABIConstructor({"type": "constructor"})
+
+ABI_CONSTRUCTOR_WITH_INPUT = ABIConstructor(
+    {
+        "inputs": [{"name": "started", "type": "str"}],
+        "type": "constructor",
+    }
+)
+
+ABI_FALLBACK = ABIFallback({"type": "fallback"})
+
+ABI_RECEIVE = ABIReceive({"type": "receive"})
+
+ABI_ERROR = ABIError({"type": "error", "name": "error"})
+
+ABI_ERROR_INVALID = ABIError(
+    {
+        "name": "Invalid",
+        "type": "error",
+        "inputs": [
+            {"type": "address", "name": "a"},
+            {"type": "bytes32", "name": "b"},
+        ],
+    }
+)
+
+# Intentionally invalid ABIError, input names are missing
+ABI_ERROR_FAILED = {
+    "type": "error",
+    "name": "failed",
     "inputs": [
-        {"type": "address", "name": "a"},
-        {"type": "bytes32", "name": "b"},
-        {"type": "address", "name": "c"},
+        {"x": b"1", "type": "bytes32"},
+        {"y": "value", "type": "str"},
     ],
 }
-FN_ABI_NESTED_TUPLE_INPUTS = {
+
+ABI_ERROR_MY_ERROR = ABIError({"type": "error", "name": "myError"})
+
+ABI_EVENT_FINISHED = ABIEvent({"type": "event", "name": "finished", "inputs": []})
+
+ABI_EVENT_FOO = ABIEvent({"type": "event", "name": "foo"})
+
+# Intentionally invalid ABIEvent, missing event name and input names
+ABI_EVENT_NO_NAME = {
+    "type": "event",
     "inputs": [
-        {
-            "components": [
-                {"name": "anAddress", "type": "address"},
-                {"name": "anInt", "type": "uint256"},
-                {"name": "someBytes", "type": "bytes"},
-                {
-                    "name": "aTuple",
-                    "type": "tuple",
-                    "components": [
-                        {"name": "anAddress", "type": "address"},
-                        {"name": "anInt", "type": "uint256"},
-                        {"name": "someBytes", "type": "bytes"},
-                    ],
-                },
-            ],
-            "type": "tuple",
-        }
-    ],
-    "name": "nestedTupleInputs",
-    "type": "function",
-}
-FN_ABI_NO_INPUTS = {"name": "noInputs", "type": "function"}
-FN_ABI_ZERO_TUPLE_INPUT = {
-    "inputs": [{"components": [], "type": "tuple"}],
-    "name": "zeroTupleInput",
-    "type": "function",
-}
-FN_ABI_SINGLETON_TUPLE_INPUT = {
-    "inputs": [
-        {"components": [{"name": "anAddress", "type": "address"}], "type": "tuple"}
-    ],
-    "name": "singletonTupleInput",
-    "type": "function",
-}
-FN_ABI_ARRAY_OF_TUPLES = {
-    "name": "tupleArrayInput",
-    "type": "function",
-    "inputs": [
-        {
-            "type": "tuple[]",
-            "components": [
-                {"name": "anAddress", "type": "address"},
-                {"name": "anInt", "type": "uint256"},
-                {"name": "someBytes", "type": "bytes"},
-            ],
-        }
+        {"x": 1, "type": "int"},
     ],
 }
-FN_ABI_FIXED_ARRAY_OF_TUPLES = {
-    "name": "tupleFixedArrayInput",
-    "type": "function",
-    "inputs": [
-        {
-            "type": "tuple[5]",
-            "components": [
-                {"name": "anAddress", "type": "address"},
-                {"name": "anInt", "type": "uint256"},
-                {"name": "someBytes", "type": "bytes"},
-            ],
-        }
-    ],
-}
+
+ABI_EVENT_TRANSFER = ABIEvent(
+    {
+        "anonymous": False,
+        "name": "Transfer",
+        "type": "event",
+        "inputs": [
+            ABIComponentIndexed({"indexed": True, "name": "from", "type": "address"}),
+            ABIComponentIndexed({"indexed": True, "name": "to", "type": "address"}),
+            ABIComponentIndexed({"indexed": False, "name": "value", "type": "uint256"}),
+        ],
+    }
+)
+
+ABI_EVENT_LOG_NO_ARG = ABIEvent(
+    {
+        "anonymous": False,
+        "name": "LogNoArg",
+        "type": "event",
+        "inputs": [],
+    }
+)
+
+ABI_EVENT_LOG_SINGLE_ARG = ABIEvent(
+    {
+        "anonymous": False,
+        "name": "LogSingleArg",
+        "type": "event",
+        "inputs": [{"name": "arg0", "type": "uint256"}],
+    }
+)
+
+ABI_EVENT_LOG_SINGLE_WITH_INDEX = ABIEvent(
+    {
+        "anonymous": False,
+        "name": "LogSingleWithIndex",
+        "type": "event",
+        "inputs": [
+            ABIComponentIndexed({"indexed": True, "name": "arg0", "type": "uint256"})
+        ],
+    }
+)
+
+ABI_EVENT_LOG_TWO_EVENTS = ABIEvent(
+    {
+        "anonymous": False,
+        "name": "logTwoEvents",
+        "type": "event",
+        "inputs": [
+            {"name": "_arg0", "type": "uint256"},
+        ],
+    }
+)
+
+ABI_EVENT_LOG_MULTI_ARGS = ABIEvent(
+    {
+        "type": "event",
+        "name": "LogMultiArg",
+        "inputs": [
+            {"name": "arg0", "type": "uint256"},
+            {"name": "arg1", "type": "uint256"},
+            {"name": "arg2", "type": "uint256"},
+        ],
+    }
+)
+
+ABI_COMPONENT = ABIComponent({"type": "str", "name": "aComponent"})
+
+ABI_COMPONENT_TUPLE = ABIComponent(
+    {
+        "components": [
+            {"name": "anAddress", "type": "address"},
+            {"name": "anInt", "type": "uint256"},
+            {"name": "someBytes", "type": "bytes"},
+        ],
+        "type": "tuple",
+        "name": "aTuple",
+    }
+)
+
+ABI_COMPONENT_TUPLE_ARRAY = ABIComponent(
+    {
+        "components": [
+            {"name": "bytes32", "type": "bytes32[]"},
+            {"name": "bytes", "type": "bytes"},
+            {"name": "someMoarBytes", "type": "bytes"},
+        ],
+        "type": "tuple[]",
+        "name": "aTupleArray",
+    }
+)
+
+ABI_COMPONENT_MULTI_DIM_TUPLE = ABIComponent(
+    {
+        "components": [
+            {"name": "anAddress", "type": "address"},
+            {"name": "anInt", "type": "uint256"},
+            {"name": "someBytes", "type": "bytes"},
+        ],
+        "type": "tuple[3]",
+        "name": "aMultiDimensionalTuple",
+    }
+)
+
+
+def build_contract_abi(abi_elements: Sequence[ABIElement]) -> ABI:
+    return cast(ABI, abi_elements)
 
 
 @pytest.mark.parametrize(
-    "fn_abi,expected",
-    ((FN_ABI_A, "0xde78e78a"), (FN_ABI_B, "0xc51bf934"), (FN_ABI_C, "0xa31d5580")),
+    "abi_element,expected",
+    (
+        (ABI_FUNCTION_TOKEN_LAUNCHED, "0xde78e78a"),
+        (ABI_FUNCTION_CEILING, "0xc51bf934"),
+        (ABI_FUNCTION_REGISTRAR, "0xa31d5580"),
+        (ABI_FUNCTION_NO_INPUTS, "0xc1772ae8"),
+        (ABI_FUNCTION_NESTED_TUPLE_INPUTS, "0xfa89ea29"),
+        (ABI_EVENT_FINISHED, "0xbef4876b"),
+        (ABI_EVENT_FOO, "0xc2985578"),
+        (ABI_EVENT_NO_NAME, "0x77c874c7"),
+        (ABI_FALLBACK, "0x552079dc"),
+        (ABI_RECEIVE, "0xa3e76c0f"),
+        (ABI_CONSTRUCTOR, "0x90fa17bb"),
+        (ABI_CONSTRUCTOR_WITH_INPUT, "0x2757c293"),
+        (ABI_ERROR_FAILED, "0x236ac042"),
+    ),
 )
-def test_fn_abi_to_4byte_selector(fn_abi, expected):
-    bytes_selector = function_abi_to_4byte_selector(fn_abi)
+def test_fn_abi_to_4byte_selector(abi_element: ABIElement, expected: HexStr) -> None:
+    bytes_selector = function_abi_to_4byte_selector(abi_element)
     hex_selector = encode_hex(bytes_selector)
     assert hex_selector == expected
 
@@ -104,58 +526,544 @@ def test_fn_abi_to_4byte_selector(fn_abi, expected):
         ("tokenLaunched()", "0xde78e78a"),
         ("CEILING()", "0xc51bf934"),
         ("Registrar(address,bytes32,address)", "0xa31d5580"),
+        ("failed(bytes32,str)", "0x236ac042"),
+        ("receive()", "0xa3e76c0f"),
+        ("fallback()", "0x552079dc"),
+        ("constructor()", "0x90fa17bb"),
     ),
 )
-def test_fn_signature_to_4byte_selector(signature, expected):
+def test_fn_signature_to_4byte_selector(signature: str, expected: HexStr) -> None:
     bytes_selector = function_signature_to_4byte_selector(signature)
     hex_selector = encode_hex(bytes_selector)
     assert hex_selector == expected
 
 
 @pytest.mark.parametrize(
-    "abi,expected",
+    "abi_element,expected",
     (
+        (ABI_FUNCTION_NO_NAME, "function()"),
+        (ABI_FUNCTION_NO_INPUTS, "noInputs()"),
+        (ABI_FUNCTION_ARRAY_OF_TUPLES, "tupleArrayInput((address,uint256,bytes)[])"),
         (
-            FN_ABI_NESTED_TUPLE_INPUTS,
-            "nestedTupleInputs((address,uint256,bytes,(address,uint256,bytes)))",
-        ),
-        (FN_ABI_NO_INPUTS, "noInputs()"),
-        (FN_ABI_ARRAY_OF_TUPLES, "tupleArrayInput((address,uint256,bytes)[])"),
-        (
-            FN_ABI_FIXED_ARRAY_OF_TUPLES,
+            ABI_FUNCTION_FIXED_ARRAY_OF_TUPLES,
             "tupleFixedArrayInput((address,uint256,bytes)[5])",
         ),
-        (FN_ABI_ZERO_TUPLE_INPUT, "zeroTupleInput(())"),
-        (FN_ABI_SINGLETON_TUPLE_INPUT, "singletonTupleInput((address))"),
+        (
+            ABI_FUNCTION_NESTED_TUPLE_INPUTS,
+            "nestedTupleInputs((address,uint256,bytes,(address,uint256,bytes)))",
+        ),
+        (ABI_FUNCTION_ZERO_TUPLE_INPUT, "zeroTupleInput(())"),
+        (ABI_FUNCTION_SINGLETON_TUPLE_INPUT, "singletonTupleInput((address))"),
+        (
+            ABI_ERROR_FAILED,
+            "failed(bytes32,str)",
+        ),
+        (ABI_ERROR_MY_ERROR, "myError()"),
+        (ABI_EVENT_FOO, "foo()"),
+        (
+            ABI_EVENT_NO_NAME,
+            "event(int)",
+        ),
+        (ABI_EVENT_LOG_MULTI_ARGS, "LogMultiArg(uint256,uint256,uint256)"),
+        (ABI_CONSTRUCTOR, "constructor()"),
+        (
+            ABI_CONSTRUCTOR_WITH_INPUT,
+            "constructor(str)",
+        ),
+        (ABI_FALLBACK, "fallback()"),
+        (ABI_RECEIVE, "receive()"),
+        (ABI_ERROR, "error()"),
     ),
 )
-def test__abi_to_signature(abi, expected):
-    assert _abi_to_signature(abi) == expected
-
-
-EVENT_ABI_A = {
-    "anonymous": False,
-    "name": "Transfer",
-    "type": "event",
-    "inputs": [
-        {"indexed": True, "name": "from", "type": "address"},
-        {"indexed": True, "name": "to", "type": "address"},
-        {"indexed": False, "name": "value", "type": "uint256"},
-    ],
-}
+def test_abi_to_signature(abi_element: ABIElement, expected: str) -> None:
+    assert abi_to_signature(abi_element) == expected
 
 
 @pytest.mark.parametrize(
-    "event_abi,expected",
+    "abi_elements,expected_event_abis",
     (
         (
-            EVENT_ABI_A,
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+            [],
+        ),
+        (
+            [
+                ABI_EVENT_LOG_NO_ARG,
+                ABI_EVENT_LOG_SINGLE_ARG,
+                ABI_EVENT_LOG_SINGLE_WITH_INDEX,
+            ],
+            [
+                ABI_EVENT_LOG_NO_ARG,
+                ABI_EVENT_LOG_SINGLE_ARG,
+                ABI_EVENT_LOG_SINGLE_WITH_INDEX,
+            ],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_EVENT_LOG_NO_ARG,
+                ABI_ERROR,
+            ],
+            [
+                ABI_EVENT_LOG_NO_ARG,
+            ],
+        ),
+        (
+            [ABI_FUNCTION_ADD],
+            [],
+        ),
+        (
+            [
+                ABI_FUNCTION_ADD,
+                ABI_FALLBACK,
+                ABI_RECEIVE,
+                ABI_CONSTRUCTOR_WITH_INPUT,
+                ABI_ERROR_FAILED,
+            ],
+            [],
+        ),
+        (
+            [
+                ABI_EVENT_LOG_NO_ARG,
+                ABI_FUNCTION_ADD,
+                ABI_FALLBACK,
+                ABI_RECEIVE,
+                ABI_CONSTRUCTOR_WITH_INPUT,
+                ABI_EVENT_LOG_SINGLE_WITH_INDEX,
+            ],
+            [
+                ABI_EVENT_LOG_NO_ARG,
+                ABI_EVENT_LOG_SINGLE_WITH_INDEX,
+            ],
         ),
     ),
 )
-def test_event_abi_to_log_topic(event_abi, expected):
-    bytes_topic = event_abi_to_log_topic(event_abi)
+def test_get_all_event_abis(
+    abi_elements: Sequence[ABIElement], expected_event_abis: Sequence[ABIEvent]
+) -> None:
+    contract_abi = build_contract_abi(abi_elements)
+    assert get_all_event_abis(contract_abi) == expected_event_abis
+
+
+@pytest.mark.parametrize(
+    "abi_elements,abi_name,expected_element_abis",
+    (
+        (
+            [ABI_EVENT_LOG_NO_ARG],
+            "LogNoArg",
+            [ABI_EVENT_LOG_NO_ARG],
+        ),
+        (
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+            "tokenLaunched",
+            [ABI_FUNCTION_TOKEN_LAUNCHED],
+        ),
+        (
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+            "notafunction",
+            [],
+        ),
+        (
+            [ABI_ERROR_INVALID],
+            "Invalid",
+            [ABI_ERROR_INVALID],
+        ),
+        (
+            [ABI_RECEIVE],  # receive abi has no name
+            "receive",
+            [],
+        ),
+        (
+            [ABI_FALLBACK],  # fallback abi has no name
+            "fallback",
+            [],
+        ),
+        (
+            [ABI_CONSTRUCTOR_WITH_INPUT],  # constructor abi has no name
+            "constructor",
+            [],
+        ),
+        (
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_TOKEN_LAUNCHED],
+            "tokenLaunched",
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_TOKEN_LAUNCHED],
+        ),
+        (
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_TOKEN_LAUNCHED_WITH_INPUT],
+            "tokenLaunched",
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_TOKEN_LAUNCHED_WITH_INPUT],
+        ),
+    ),
+)
+def test_filter_abi_by_name(
+    abi_elements: Sequence[ABIElement],
+    abi_name: str,
+    expected_element_abis: Sequence[ABIElement],
+) -> None:
+    contract_abi = build_contract_abi(abi_elements)
+    assert filter_abi_by_name(abi_name, contract_abi) == expected_element_abis
+
+
+@pytest.mark.parametrize(
+    "abi_elements,abi_type,expected_element_abis",
+    (
+        (
+            [
+                ABI_EVENT_LOG_TWO_EVENTS,
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+            ],
+            "function",
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_EVENT_LOG_TWO_EVENTS,
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+            ],
+            "event",
+            [ABI_EVENT_LOG_TWO_EVENTS],
+        ),
+        (
+            [
+                ABI_FALLBACK,
+            ],
+            "fallback",
+            [ABI_FALLBACK],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+            ],
+            "fallback",
+            [],
+        ),
+        (
+            [
+                ABI_RECEIVE,
+                ABI_FALLBACK,
+            ],
+            "receive",
+            [ABI_RECEIVE],
+        ),
+        (
+            [
+                ABI_CONSTRUCTOR_WITH_INPUT,
+            ],
+            "constructor",
+            [ABI_CONSTRUCTOR_WITH_INPUT],
+        ),
+        (
+            [
+                ABI_EVENT_LOG_TWO_EVENTS,
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+            ],
+            "notatype",
+            [],
+        ),
+    ),
+)
+def test_filter_abi_by_type(
+    abi_elements: Sequence[ABIElement],
+    abi_type: str,
+    expected_element_abis: Sequence[ABIElement],
+) -> None:
+    contract_abi = build_contract_abi(abi_elements)
+    assert filter_abi_by_type(abi_type, contract_abi) == expected_element_abis
+
+
+@pytest.mark.parametrize(
+    "abi_element,expected_names,expected_types",
+    (
+        (
+            ABI_EVENT_LOG_SINGLE_ARG,
+            ["arg0"],
+            ["uint256"],
+        ),
+        (
+            ABI_EVENT_LOG_SINGLE_WITH_INDEX,
+            ["arg0"],
+            ["uint256"],
+        ),
+        (
+            ABI_EVENT_LOG_MULTI_ARGS,
+            ["arg0", "arg1", "arg2"],
+            ["uint256", "uint256", "uint256"],
+        ),
+        (
+            ABI_EVENT_LOG_NO_ARG,
+            [],
+            [],
+        ),
+        (
+            ABI_FUNCTION_SINGLE_ARG,
+            ["arg0"],
+            ["uint256"],
+        ),
+        (
+            ABI_FUNCTION_TWO_NAMED_ARGS,
+            ["arg0", "arg1"],
+            ["uint256", "uint256"],
+        ),
+        (
+            ABI_FUNCTION_MULTI_TYPED_ARGS,
+            ["arg0", "arg1"],
+            ["uint256", "bytes32"],
+        ),
+        (
+            ABI_FUNCTION_TWO_UNNAMED_ARGS,
+            ["", ""],
+            ["int256", "int256"],
+        ),
+        (
+            ABI_FUNCTION_TUPLE_INPUT_WITH_OUTPUTS,
+            ["aTuple"],
+            ["(uint256)"],
+        ),
+        (
+            ABI_FUNCTION_TUPLE_INPUT_WITH_MULTI_TYPE_OUTPUTS,
+            ["aTuple"],
+            ["(uint256)"],
+        ),
+        (
+            ABI_CONSTRUCTOR_WITH_INPUT,
+            ["started"],
+            ["str"],
+        ),
+        (
+            ABI_FUNCTION_NO_INPUTS,
+            [],
+            [],
+        ),
+        (
+            ABI_ERROR_INVALID,
+            ["a", "b"],
+            ["address", "bytes32"],
+        ),
+    ),
+)
+def test_get_input_names_and_types_from_abi_element(
+    abi_element: ABIElement,
+    expected_names: Sequence[str],
+    expected_types: Sequence[str],
+) -> None:
+    assert get_abi_input_names(abi_element) == expected_names
+    assert get_abi_input_types(abi_element) == expected_types
+
+
+@pytest.mark.parametrize(
+    "abi_element",
+    (
+        ABI_FALLBACK,
+        ABI_RECEIVE,
+    ),
+)
+def test_get_input_names_and_types_raises_for_fallback_or_receive_abi(
+    abi_element: ABIElement,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=f"Inputs not supported for function types `fallback` or `receive`."
+        f" Provided ABI type was `{abi_element['type']}` with inputs"
+        f" `None`.",
+    ):
+        get_abi_input_names(abi_element)
+
+    with pytest.raises(
+        ValueError,
+        match=f"Inputs not supported for function types `fallback` or `receive`."
+        f" Provided ABI type was `{abi_element['type']}` with inputs"
+        f" `None`.",
+    ):
+        get_abi_input_types(abi_element)
+
+
+@pytest.mark.parametrize(
+    "abi_element,expected_names,expected_types",
+    [
+        (
+            ABI_FUNCTION_SINGLE_ARG,
+            ["arg0"],
+            ["uint256"],
+        ),
+        (
+            ABI_FUNCTION_TWO_NAMED_ARGS,
+            ["arg0", "arg1"],
+            ["uint256", "uint256"],
+        ),
+        (
+            ABI_FUNCTION_MULTI_TYPED_ARGS,
+            ["arg0", "arg1"],
+            ["uint256", "bytes32"],
+        ),
+        (
+            ABI_FUNCTION_TWO_UNNAMED_ARGS,
+            [],
+            [],
+        ),
+        (
+            ABI_FUNCTION_NO_INPUTS,
+            [],
+            [],
+        ),
+        (
+            ABI_FUNCTION_TUPLE_INPUT_WITH_OUTPUTS,
+            ["y"],
+            ["uint256"],
+        ),
+        (
+            ABI_FUNCTION_TUPLE_INPUT_WITH_MULTI_TYPE_OUTPUTS,
+            ["anAddress", "anInt", "someBytes"],
+            ["address", "uint256", "bytes"],
+        ),
+    ],
+)
+def test_get_abi_output_names(
+    abi_element: ABIElement,
+    expected_names: Sequence[str],
+    expected_types: Sequence[str],
+) -> None:
+    assert get_abi_output_names(abi_element) == expected_names
+    assert get_abi_output_types(abi_element) == expected_types
+
+
+@pytest.mark.parametrize(
+    "abi_element",
+    (
+        ABI_CONSTRUCTOR,
+        ABI_CONSTRUCTOR_WITH_INPUT,
+        ABI_EVENT_FINISHED,
+        ABI_EVENT_LOG_NO_ARG,
+        ABI_ERROR,
+        ABI_ERROR_INVALID,
+        ABI_FALLBACK,
+        ABI_RECEIVE,
+    ),
+)
+def test_get_abi_output_names_raises_for_non_function_types(
+    abi_element: ABIElement,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=f"Outputs only supported for ABI type `function`."
+        f" Provided ABI type was `{abi_element['type']}` and outputs were `None`.",
+    ):
+        get_abi_output_names(abi_element)
+
+    with pytest.raises(
+        ValueError,
+        match=f"Outputs only supported for ABI type `function`."
+        f" Provided ABI type was `{abi_element['type']}` and outputs were `None`.",
+    ):
+        get_abi_output_types(abi_element)
+
+
+@pytest.mark.parametrize(
+    "abi_elements,expected_function_abis",
+    (
+        (
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+                ABI_EVENT_LOG_NO_ARG,
+            ],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+                ABI_ERROR_INVALID,
+            ],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+                ABI_FALLBACK,
+            ],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+                ABI_RECEIVE,
+                ABI_ERROR,
+            ],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+                ABI_CONSTRUCTOR_WITH_INPUT,
+            ],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [
+                ABI_FUNCTION_TOKEN_LAUNCHED,
+                ABI_FUNCTION_CEILING,
+                ABI_FUNCTION_REGISTRAR,
+                ABI_FALLBACK,
+                ABI_RECEIVE,
+                ABI_CONSTRUCTOR_WITH_INPUT,
+            ],
+            [ABI_FUNCTION_TOKEN_LAUNCHED, ABI_FUNCTION_CEILING, ABI_FUNCTION_REGISTRAR],
+        ),
+        (
+            [ABI_FALLBACK, ABI_RECEIVE, ABI_CONSTRUCTOR_WITH_INPUT, ABI_ERROR_INVALID],
+            [],
+        ),
+    ),
+)
+def test_get_all_function_abis(
+    abi_elements: Sequence[ABIElement], expected_function_abis: Sequence[ABIFunction]
+) -> None:
+    contract_abi = build_contract_abi(abi_elements)
+    function_abis = get_all_function_abis(contract_abi)
+    assert function_abis == expected_function_abis
+
+
+@pytest.mark.parametrize(
+    "abi_event,expected",
+    (
+        (
+            ABI_EVENT_TRANSFER,
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        ),
+        (
+            ABI_EVENT_FINISHED,
+            "0xbef4876bcdde2983a1ba9fe22b5983b09081cf602d266f72a613d0d9c2f78e28",
+        ),
+        (
+            ABI_EVENT_LOG_SINGLE_ARG,
+            "0x56d2ef3c5228bf5d88573621e325a4672ab50e033749a601e4f4a5e1dce905d4",
+        ),
+        (
+            ABI_EVENT_NO_NAME,
+            "0x77c874c798a153cb8bb91a65910a8f49033a603329228caa4b3b1bb4bb5b9e18",
+        ),
+    ),
+)
+def test_event_abi_to_log_topic(abi_event: ABIEvent, expected: HexStr) -> None:
+    bytes_topic = event_abi_to_log_topic(abi_event)
     hex_topic = encode_hex(bytes_topic)
     assert hex_topic == expected
 
@@ -167,9 +1075,457 @@ def test_event_abi_to_log_topic(event_abi, expected):
             "Transfer(address,address,uint256)",
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
         ),
+        (
+            "Event_2(bytes32,uint256)",
+            "0x115494e95409cd09eaa4590f66d8938bb342c170bc2edcca5fd14ad46fb7dcb8",
+        ),
+        (
+            "event()",
+            "0x4980500b48d9072058dce7e5222cd23e11759678f8aa74b3a6f0e891bb888979",
+        ),
     ),
 )
-def test_event_signature_to_log_topic(event_signature, expected):
+def test_event_signature_to_log_topic(event_signature: str, expected: HexStr) -> None:
     bytes_topic = event_signature_to_log_topic(event_signature)
     hex_topic = encode_hex(bytes_topic)
     assert hex_topic == expected
+
+
+@pytest.mark.parametrize(
+    "abi_component,expected_type_signature",
+    (
+        (
+            ABI_COMPONENT_TUPLE,
+            "(address,uint256,bytes)",
+        ),
+        (
+            ABI_COMPONENT_TUPLE_ARRAY,
+            "(bytes32[],bytes,bytes)[]",
+        ),
+        (
+            ABI_COMPONENT_MULTI_DIM_TUPLE,
+            "(address,uint256,bytes)[3]",
+        ),
+        (
+            ABI_COMPONENT,
+            "str",
+        ),
+        (
+            (
+                {
+                    "type": "uint256",
+                }
+            ),
+            "uint256",
+        ),
+        (
+            "uint256",
+            "uint256",
+        ),
+    ),
+)
+def test_collapse_if_tuple(
+    abi_component: Union[ABIComponent, Dict[str, Any], str],
+    expected_type_signature: str,
+) -> None:
+    assert collapse_if_tuple(abi_component) == expected_type_signature
+
+
+@pytest.mark.parametrize(
+    "abi_component,message",
+    (
+        (
+            {
+                "type": False,
+            },
+            "The 'type' must be a string, but got False of type <class 'bool'>",
+        ),
+        (
+            {
+                "type": "tuple",
+                "components": [{"type": 1}],
+            },
+            "The 'type' must be a string, but got 1 of type <class 'int'>",
+        ),
+        (
+            {"name": "notype"},
+            "The 'type' must be a string, but got None of type <class 'NoneType'>",
+        ),
+    ),
+)
+def test_collapse_if_tuple_raises_for_invalid_component(
+    abi_component: Union[ABIComponent, Dict[str, Any], str],
+    message: str,
+) -> None:
+    with pytest.raises(TypeError, match=re.escape(message)):
+        collapse_if_tuple(abi_component)
+
+
+@pytest.mark.parametrize(
+    "abi_element,args,kwargs,expected",
+    (
+        (
+            ABI_FUNCTION_REGISTRAR,
+            (
+                "0x1234567890123456789012345678901234567890",
+                b"bar",
+                "0x1234567890123456789012345678901234567890",
+            ),
+            {},
+            (
+                "0x1234567890123456789012345678901234567890",
+                b"bar",
+                "0x1234567890123456789012345678901234567890",
+            ),
+        ),
+        (
+            ABI_FUNCTION_REGISTRAR,
+            [],
+            {
+                "a": "0x1234567890123456789012345678901234567890",
+                "b": b"bar",
+                "c": "0x1234567890123456789012345678901234567890",
+            },
+            (
+                "0x1234567890123456789012345678901234567890",
+                b"bar",
+                "0x1234567890123456789012345678901234567890",
+            ),
+        ),
+        (
+            ABI_FUNCTION_REGISTRAR,
+            [1, "0x1234567890123456789012345678901234567890", b"bar"],
+            {},
+            (
+                1,
+                "0x1234567890123456789012345678901234567890",
+                b"bar",
+            ),
+        ),
+        (
+            ABI_FUNCTION_TWO_UNNAMED_ARGS,
+            (1, 2),
+            {},
+            (1, 2),
+        ),
+        (
+            ABI_FUNCTION_THREE_NAMED_ARGS_DUPLICATE,
+            (1, 2, 3),
+            {},
+            (1, 2, 3),
+        ),
+        (
+            ABI_ERROR_INVALID,
+            (
+                "0x1234567890123456789012345678901234567890",
+                b"bar",
+            ),
+            {},
+            (
+                "0x1234567890123456789012345678901234567890",
+                b"bar",
+            ),
+        ),
+        (
+            ABI_EVENT_LOG_TWO_EVENTS,
+            (1,),
+            {},
+            (1,),
+        ),
+        (
+            ABI_FUNCTION_TOKEN_LAUNCHED,
+            (),
+            {},
+            (),
+        ),
+        (
+            ABI_FUNCTION_NO_INPUTS,
+            (),
+            {},
+            (),
+        ),
+    ),
+)
+def test_get_normalized_abi_inputs(
+    abi_element: ABIElement,
+    args: Sequence[Any],
+    kwargs: Dict[str, Any],
+    expected: Tuple[Any, ...],
+) -> None:
+    assert get_normalized_abi_inputs(abi_element, *args, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "abi_element,args,kwargs,error_type,message",
+    (
+        (
+            ABI_FALLBACK,
+            (),
+            {},
+            ValueError,
+            "Inputs not supported for function types `fallback` or `receive`. "
+            "Provided ABI type was `fallback` with inputs `None`.",
+        ),
+        (
+            ABI_RECEIVE,
+            (),
+            {},
+            ValueError,
+            "Inputs not supported for function types `fallback` or `receive`. "
+            "Provided ABI type was `receive` with inputs `None`.",
+        ),
+        (
+            ABI_FUNCTION_THREE_NAMED_ARGS_DUPLICATE,
+            (1,),
+            {"a": 2, "b": 3},
+            TypeError,
+            "threeNamedArgs() got multiple values for argument(s) 'b'",
+        ),
+        (
+            ABI_FUNCTION_THREE_NAMED_ARGS_DUPLICATE,
+            (1,),
+            {"d": 2, "e": 3},
+            TypeError,
+            "threeNamedArgs() got unexpected keyword argument(s) 'd, e",
+        ),
+        (
+            ABI_FUNCTION_TWO_UNNAMED_ARGS,
+            tuple(),
+            {"x": 1, "y": 2},
+            TypeError,
+            "twoUnnamedArgs() got unexpected keyword argument(s) 'x, y'",
+        ),
+        (
+            ABI_FUNCTION_TWO_UNNAMED_ARGS,
+            (
+                1,
+                2,
+            ),
+            {"a": 1, "b": 2},
+            TypeError,
+            "Incorrect argument count. Expected '2', got '4'.",
+        ),
+        (
+            ABI_ERROR_INVALID,
+            (),
+            {},
+            TypeError,
+            "Incorrect argument count. Expected '2', got '0'.",
+        ),
+    ),
+)
+def test_get_normalized_abi_inputs_raises_for_invalid_arguments(
+    abi_element: ABIElement,
+    args: Sequence[Any],
+    kwargs: Dict[str, Any],
+    error_type: Type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(
+        error_type,
+        match=re.escape(message),
+    ):
+        get_normalized_abi_inputs(abi_element, *args, **kwargs)
+
+
+class MyXYTuple(NamedTuple):
+    x: int
+    y: int
+
+
+GET_ABI_INPUTS_OUTPUT = (
+    (
+        "(uint256,uint256[],(uint256,uint256)[])",  # Type of s
+        "(uint256,uint256)",  # Type of t
+        "uint256",  # Type of a
+        "(uint256,uint256)[][]",  # Type of b
+    ),
+    (
+        (1, [2, 3, 4], [(5, 6), (7, 8), (9, 10)]),  # Value for s
+        (11, 12),  # Value for t
+        13,  # Value for a
+        [[(14, 15), (16, 17)], [(18, 19)]],  # Value for b
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "abi_element,args,expected",
+    (
+        (
+            ABI_FUNCTION_REGISTRAR,
+            {
+                "a": 1,
+                "b": 2,
+                "c": 3,
+            },  # mapping of arguments
+            (
+                ("address", "bytes32", "address"),
+                (1, 2, 3),
+            ),
+        ),
+        (
+            ABI_FUNCTION_REGISTRAR,
+            (1, 2, 3),  # tuple of arguments
+            (
+                ("address", "bytes32", "address"),
+                (1, 2, 3),
+            ),
+        ),
+        (
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": {
+                    "a": 1,
+                    "b": [2, 3, 4],
+                    "c": [{"x": 5, "y": 6}, {"x": 7, "y": 8}, {"x": 9, "y": 10}],
+                },
+                "t": {"x": 11, "y": 12},
+                "a": 13,
+                "b": [[{"x": 14, "y": 15}, {"x": 16, "y": 17}], [{"x": 18, "y": 19}]],
+            },
+            GET_ABI_INPUTS_OUTPUT,
+        ),
+        (
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": {"a": 1, "b": [2, 3, 4], "c": [(5, 6), (7, 8), {"x": 9, "y": 10}]},
+                "t": {"x": 11, "y": 12},
+                "a": 13,
+                "b": [[(14, 15), (16, 17)], [{"x": 18, "y": 19}]],
+            },
+            GET_ABI_INPUTS_OUTPUT,
+        ),
+        (
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": {"a": 1, "b": [2, 3, 4], "c": [(5, 6), (7, 8), (9, 10)]},
+                "t": (11, 12),
+                "a": 13,
+                "b": [[(14, 15), (16, 17)], [(18, 19)]],
+            },
+            GET_ABI_INPUTS_OUTPUT,
+        ),
+        (
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": (1, [2, 3, 4], [(5, 6), (7, 8), (9, 10)]),
+                "t": (11, 12),
+                "a": 13,
+                "b": [[(14, 15), (16, 17)], [(18, 19)]],
+            },
+            GET_ABI_INPUTS_OUTPUT,
+        ),
+        (
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            (
+                (1, [2, 3, 4], [(5, 6), (7, 8), (9, 10)]),
+                (11, 12),
+                13,
+                [[(14, 15), (16, 17)], [(18, 19)]],
+            ),
+            GET_ABI_INPUTS_OUTPUT,
+        ),
+        (
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": {
+                    "a": 1,
+                    "b": [2, 3, 4],
+                    "c": [(5, 6), (7, 8), MyXYTuple(x=9, y=10)],
+                },
+                "t": MyXYTuple(x=11, y=12),
+                "a": 13,
+                "b": [
+                    [MyXYTuple(x=14, y=15), MyXYTuple(x=16, y=17)],
+                    [MyXYTuple(x=18, y=19)],
+                ],
+            },
+            GET_ABI_INPUTS_OUTPUT,
+        ),
+        (
+            ABI_EVENT_LOG_SINGLE_ARG,
+            (1,),
+            (("uint256",), (1,)),
+        ),
+        (
+            ABI_ERROR_INVALID,
+            ("0x1234567890123456789012345678901234567890", b"bar"),
+            (
+                ("address", "bytes32"),
+                ("0x1234567890123456789012345678901234567890", b"bar"),
+            ),
+        ),
+        (
+            ABI_FUNCTION_NO_INPUTS,
+            (),
+            (
+                (),
+                (),
+            ),
+        ),
+    ),
+)
+def test_get_aligned_abi_inputs(
+    abi_element: ABIElement,
+    args: Union[Tuple[Any, ...], Mapping[Any, Any]],
+    expected: Tuple[Tuple[str, ...], Tuple[Any, ...]],
+) -> None:
+    assert get_aligned_abi_inputs(abi_element, args) == expected
+
+
+@pytest.mark.parametrize(
+    "abi_element,args,error_type,message",
+    (
+        (
+            # raise TypeError, expects list of tuples for input 's.c'
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": {"a": 1, "b": [2, 3, 4], "c": ["56", (7, 8), (9, 10)]},
+                "t": (11, 12),
+                "a": 13,
+                "b": [[(14, 15), (16, 17)], [(18, 19)]],
+            },
+            TypeError,
+            'Expected non-string sequence for "tuple" component type: got 56',
+        ),
+        (
+            # raise TypeError, expects list of tuples for input 's.c'
+            ABI_FUNCTION_MULTI_TUPLE_INPUTS,
+            {
+                "s": {"a": 1, "b": [2, 3, 4], "c": {(5, 6), (7, 8), (9, 10)}},
+                "t": (11, 12),
+                "a": 13,
+                "b": [[(14, 15), (16, 17)], [(18, 19)]],
+            },
+            TypeError,
+            'Expected non-string sequence for "tuple[]" component type: got '
+            "{(9, 10), (5, 6), (7, 8)}",
+        ),
+        (
+            ABI_FALLBACK,
+            (),
+            ValueError,
+            "Inputs not supported for function types `fallback` or `receive`. "
+            "Provided ABI type was `fallback` with inputs `None`.",
+        ),
+        (
+            ABI_RECEIVE,
+            (),
+            ValueError,
+            "Inputs not supported for function types `fallback` or `receive`. "
+            "Provided ABI type was `receive` with inputs `None`.",
+        ),
+    ),
+)
+def test_get_aligned_abi_inputs_raises_type_error_for_incorrect_input_types(
+    abi_element: ABIElement,
+    args: Union[Tuple[Any, ...], Mapping[Any, Any]],
+    error_type: Type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(
+        error_type,
+        match=re.escape(message),
+    ):
+        get_aligned_abi_inputs(abi_element, args)

--- a/tests/mypy/abi_types.py
+++ b/tests/mypy/abi_types.py
@@ -1,0 +1,42 @@
+# no-unused-vars
+from typing import (
+    Sequence,
+)
+
+from eth_utils import (
+    filter_abi_by_type,
+)
+from eth_utils.abi import (
+    ABIConstructor,
+    ABIError,
+    ABIEvent,
+    ABIFallback,
+    ABIFunction,
+    ABIReceive,
+)
+
+
+def test_filter_abi_by_type_function() -> None:
+    _result: Sequence[ABIFunction] = filter_abi_by_type("function", [])  # noqa: F841
+
+
+def test_filter_abi_by_type_constructor() -> None:
+    _result: Sequence[ABIConstructor] = filter_abi_by_type(  # noqa: F841
+        "constructor", []
+    )
+
+
+def test_filter_abi_by_type_fallback() -> None:
+    _result: Sequence[ABIFallback] = filter_abi_by_type("fallback", [])  # noqa: F841
+
+
+def test_filter_abi_by_type_receive() -> None:
+    _result: Sequence[ABIReceive] = filter_abi_by_type("receive", [])  # noqa: F841
+
+
+def test_filter_abi_by_type_event() -> None:
+    _result: Sequence[ABIEvent] = filter_abi_by_type("event", [])  # noqa: F841
+
+
+def test_filter_abi_by_type_error() -> None:
+    _result: Sequence[ABIError] = filter_abi_by_type("error", [])  # noqa: F841


### PR DESCRIPTION
### What was wrong?

Contract ABI utilities are useful for encoding and decoding contract transactions. Many utilities are implemented in web3.py as private methods.

Related to https://github.com/ethereum/web3.py/issues/3036

Many of these functions were previously private in `web3.py` but these public utilities are used as of `v7`. See
https://github.com/ethereum/web3.py/pull/3408

### How was it fixed?

Implement functions for parsing and validating contract data using the ABI spec.

The following functions have been added to the `eth_utils.abi` module:
    `abi_to_signature`,
    `collapse_if_tuple`,
    `filter_abi_by_name`,
    `filter_abi_by_type`,
    `get_abi_input_names`,
    `get_abi_input_types`,
    `get_abi_output_names`,
    `get_abi_output_types`,
    `get_aligned_abi_inputs`,
    `get_all_event_abis`,
    `get_all_function_abis`,
    `get_normalized_abi_inputs`,

### Todo:

- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [X] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="692" alt="Screen Shot 2024-04-12 at 3 16 35 PM" src="https://github.com/ethereum/eth-utils/assets/435903/9c358207-df30-4675-9bd7-df9c6ceb47d8">

