### PR TITLE
♻️ remove deprecated classes

### DIFF
--- a/eth_utils/logging.py
+++ b/eth_utils/logging.py
@@ -134,26 +134,12 @@ class HasLoggerMeta(type):
         return type(mcls.__name__, (mcls, other), {})
 
 
-class _BaseHasLogger(metaclass=HasLoggerMeta):
-    # This class exists to a allow us to define the type of the logger. Once
-    # python3.5 is deprecated this can be removed in favor of a simple type
-    # annotation on the main class.
-    logger = logging.Logger("")  # type: logging.Logger
-
-
-class HasLogger(_BaseHasLogger):
-    pass
+class HasLogger(metaclass=HasLoggerMeta):
+    logger: logging.Logger
 
 
 HasExtendedDebugLoggerMeta = HasLoggerMeta.replace_logger_class(ExtendedDebugLogger)
 
 
-class _BaseHasExtendedDebugLogger(metaclass=HasExtendedDebugLoggerMeta):  # type: ignore
-    # This class exists to a allow us to define the type of the logger. Once
-    # python3.5 is deprecated this can be removed in favor of a simple type
-    # annotation on the main class.
-    logger = ExtendedDebugLogger("")  # type: ExtendedDebugLogger
-
-
-class HasExtendedDebugLogger(_BaseHasExtendedDebugLogger):
-    pass
+class HasExtendedDebugLogger(metaclass=HasExtendedDebugLoggerMeta):  # type: ignore
+    logger: ExtendedDebugLogger

--- a/newsfragments/275.feature.rst
+++ b/newsfragments/275.feature.rst
@@ -1,0 +1,1 @@
+Removed ``_BaseHasLogger`` and ``_BaseHasExtendedDebugLogger``, and the ``logger`` attribute in the ``HasLogger`` and ``HasExtendedDebugLogger`` is type hinted directly.


### PR DESCRIPTION
### What was wrong?
The `_BaseHasLogger` and `_BaseHasExtendedDebugLogger` is unnecessary

Related to Issue #262
Closes #262

### How was it fixed?
Removed these classes and update the main class

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-utils/assets/72649244/86fe5818-ea5d-435e-bf0f-179aa1515afb)
