### PR TITLE
Remove network warning spam

### DIFF
--- a/eth_utils/network.py
+++ b/eth_utils/network.py
@@ -6,7 +6,6 @@ import os
 from typing import (
     List,
 )
-import warnings
 
 from eth_typing import (
     ChainId,
@@ -47,13 +46,10 @@ def initialize_network_objects() -> List[Network]:
             )
             networks_obj.append(network)
         except ValueError:
-            # Entry does not have a valid ChainId constant in eth-typing
-            warnings.warn(
-                f"Network {entry['chainId']} with name '{entry['name']}' does not have "
-                f"a valid ChainId. eth-typing should be updated with the latest "
-                f"networks.",
-                stacklevel=2,
-            )
+            # Chain does not have a valid ChainId, network files in eth-utils and
+            # eth-typing should to be updated. Run `python update_networks.py` in the
+            # project root.
+            pass
 
     return networks_obj
 

--- a/newsfragments/278.internal.rst
+++ b/newsfragments/278.internal.rst
@@ -1,0 +1,1 @@
+No warning for outdated networks.


### PR DESCRIPTION
### What was wrong?

When networks are changed but get out of sync between eth-typing and eth-utils, warnings are thrown.

### How was it fixed?

Remove the warning, very few core networks change much. If folks need net networks, they can be added with the script.

Planning to add a CI process to run the script automatically.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://ih0.redbubble.net/image.1905315914.5391/raf,360x360,075,t,fafafa:ca443f4786.jpg)
