### PR TITLE
Deprecation warning for `collapse_if_tuple`

### DIFF
--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -1,6 +1,11 @@
 from typing import (
     Any,
     Dict,
+    Union,
+)
+
+from typing_extensions import (
+    deprecated,
 )
 
 from .crypto import (
@@ -8,8 +13,15 @@ from .crypto import (
 )
 
 
+@deprecated(
+    "`collapse_if_tuple` is deprecated, use "
+    "`get_normalized_abi_component_type` instead."
+)
 def collapse_if_tuple(abi: Dict[str, Any]) -> str:
     """
+    DEPRECATED: `collapse_if_tuple` will be removed in the next major version.
+    Use `get_normalized_abi_component_type` instead.
+
     Converts a tuple from a dict to a parenthesized list of its types.
 
     >>> from eth_utils.abi import collapse_if_tuple
@@ -66,3 +78,49 @@ def event_signature_to_log_topic(event_signature: str) -> bytes:
 def event_abi_to_log_topic(event_abi: Dict[str, Any]) -> bytes:
     event_signature = _abi_to_signature(event_abi)
     return event_signature_to_log_topic(event_signature)
+
+
+def get_normalized_abi_component_type(abi_component: Union[Dict[str, Any], str]) -> str:
+    """
+    Extract argument types from a function or event ABI parameter.
+    With tuple argument types, return a Tuple of each type.
+    Returns the param if `abi_component` is an instance of str or another non-tuple
+    type.
+    :param abi_component: A string with type info.
+    :type abi_component: `Dict[str, Any]` or `str`
+    :return: Type(s) for the function or event ABI param.
+    :rtype: `str`
+    .. doctest:
+        >>> from eth_utils.abi import get_normalized_abi_component_type
+        >>> abi_component = {
+        ...   'components': [
+        ...     {'name': 'anAddress', 'type': 'address'},
+        ...     {'name': 'anInt', 'type': 'uint256'},
+        ...     {'name': 'someBytes', 'type': 'bytes'},
+        ...   ],
+        ...   'type': 'tuple',
+        ... }
+        >>> get_normalized_abi_component_type(abi_component)
+        '(address,uint256,bytes)'
+    """
+    if isinstance(abi_component, str):
+        return abi_component
+
+    element_type = abi_component["type"]
+    if not isinstance(element_type, str):
+        raise TypeError(
+            f"The 'type' must be a string, but got {repr(element_type)} of type "
+            f"{type(element_type)}"
+        )
+    elif not element_type.startswith("tuple"):
+        return element_type
+
+    delimited = ",".join(
+        get_normalized_abi_component_type(c) for c in abi_component["components"]
+    )
+    # Whatever comes after "tuple" is the array dims. The ABI spec states that
+    # this will have the form "", "[]", or "[k]".
+    array_dim = element_type[5:]
+    collapsed = f"({delimited}){array_dim}"
+
+    return collapsed


### PR DESCRIPTION
### What was wrong?
`collapse_if_tuple` is being replaced by `get_normalized_abi_component_type` in the next major.

Need to warn users that this method will no longer be available.

Related to Issue #
Closes #

### How was it fixed?

Deprecation warning for `collapse_if_tuple` with reference to new method.

### Todo:

- [X] Clean up commit history
- [X] Add or update documentation related to these changes
- [X] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.floridamuseum.ufl.edu/wp-content/uploads/sites/116/2020/10/IMG_6335.jpg)
