### PR TITLE
run mypy linting locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
     -   id: mypy-local
         name: run mypy with all dev dependencies present
-        entry: python -m mypy -p eth_utils
+        entry: python -m mypy eth_utils tests/mypy
         language: system
         always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        exclude: tests/core
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p eth_utils
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.5
     hooks:

--- a/newsfragments/282.internal.rst
+++ b/newsfragments/282.internal.rst
@@ -1,0 +1,1 @@
+Run ``mypy`` locally via ``pre-commit`` hook, bump to ``mypy==1.10.0``

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,15 @@ from setuptools import (
     setup,
 )
 
+MYPY_REQUIREMENT = "mypy==1.10.0"
+
 extras_require = {
     "dev": [
         "build>=0.9.0",
         "bump_my_version>=0.19.0",
         "eth-hash[pycryptodome]",
         "ipython",
+        MYPY_REQUIREMENT,
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",
@@ -23,7 +26,7 @@ extras_require = {
     ],
     "test": [
         "hypothesis>=4.43.0",
-        "mypy==1.5.1",
+        MYPY_REQUIREMENT,
         "pytest>=7.0.0",
         "pytest-xdist>=2.4.0",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps=
 
 [testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
+extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
### What was wrong?

Running `mypy` in a `pre-commit` container can miss local context.

### How was it fixed?

Run `mypy` locally via a `pre-commit` hook. No new issues.
Bumped to `mypy==1.10.0`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/636b7c83-d2c1-4f4d-bb5d-478a1a56c809)
