### PR TITLE
setup: Remove cyclic dependency

### DIFF
--- a/newsfragments/284.bugfix.rst
+++ b/newsfragments/284.bugfix.rst
@@ -1,0 +1,1 @@
+Remove unused hexbytes dependency that is causing a cyclic dependency issue

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     install_requires=[
         "eth-hash>=0.3.1",
         "eth-typing>=5.0.0",
-        "hexbytes>=1.0.0",
         "toolz>0.8.2;implementation_name=='pypy'",
         "cytoolz>=0.10.1;implementation_name=='cpython'",
     ],


### PR DESCRIPTION
### What was wrong?

PR #271 introduced `hexbytes` as a unnecessary install dependency. This introduces a cyclic dependency with `hexabytes` which depends on `eth-utils` in its testsuite: https://github.com/ethereum/hexbytes/blob/main/setup.py#L24 

### How was it fixed?

This PR removes this dependency again. This fixes the cyclic dependency.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Awwmadillo](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnQ0bG45MW50bHU0b291Z2lwYTJ0NWVzdDdyaDQxMTRob3R1d2NqZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oDs9n3IoxrbPgQbOPn/giphy.gif)
