### PR TITLE
Humanize hexstr

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1381,6 +1381,28 @@ ellipsis, only showing the first and last four hexadecimal nibbles.
      '0001..1e1f'
 
 
+``humanize_hexstr(str)`` -> string
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Returns the provided hex string in a human readable format.
+
+If the value is 4 bytes or less it is returned in full in its hexadecimal representation (with a ``0x`` prefix)
+
+If the value is longer than 4 bytes it is returned in its hexadecimal
+representation with the middle segment replaced by an
+ellipsis, only showing the first and last four hexadecimal nibbles.
+
+.. doctest::
+
+    >>> from eth_utils import humanize_hexstr
+    >>> humanize_hexstr('0x1234')
+     '0x1234'
+    >>> humanize_hexstr('0x12345678')
+     '0x12345678'
+    >>> humanize_hexstr('0x10203040506070')
+     '0x1020..6070'
+
+
 ``humanize_hash(bytes)`` -> string
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -93,7 +93,7 @@ from .hexadecimal import (
 from .humanize import (
     humanize_bytes,
     humanize_hash,
-    humanize_hex_str,
+    humanize_hexstr,
     humanize_integer_sequence,
     humanize_ipfs_uri,
     humanize_seconds,

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -93,6 +93,7 @@ from .hexadecimal import (
 from .humanize import (
     humanize_bytes,
     humanize_hash,
+    humanize_hex_str,
     humanize_integer_sequence,
     humanize_ipfs_uri,
     humanize_seconds,

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -58,6 +58,7 @@ from eth_utils import (
     hexstr_if_str as non_curried_hexstr_if_str,
     humanize_bytes,
     humanize_hash,
+    humanize_hexstr,
     humanize_integer_sequence,
     humanize_ipfs_uri,
     humanize_seconds,

--- a/eth_utils/humanize.py
+++ b/eth_utils/humanize.py
@@ -86,18 +86,25 @@ DISPLAY_HASH_CHARS = 4
 def humanize_bytes(value: bytes) -> str:
     if len(value) <= DISPLAY_HASH_CHARS + 1:
         return value.hex()
-
     value_as_hex = value.hex()
-    return humanize_hex_str(value_as_hex)
-
-
-def humanize_hex_str(value: str) -> str:
-    if len(value) <= DISPLAY_HASH_CHARS * 2:
-        return value
-
-    head = value[:DISPLAY_HASH_CHARS]
-    tail = value[-1 * DISPLAY_HASH_CHARS :]
+    head = value_as_hex[:DISPLAY_HASH_CHARS]
+    tail = value_as_hex[-1 * DISPLAY_HASH_CHARS :]
     return f"{head}..{tail}"
+
+
+def humanize_hexstr(value: str) -> str:
+    tail = value[-1 * DISPLAY_HASH_CHARS :]
+
+    if value[:2] == "0x":
+        if len(value[2:]) <= DISPLAY_HASH_CHARS * 2:
+            return value
+        head = value[2 : DISPLAY_HASH_CHARS + 2]
+        return f"0x{head}..{tail}"
+    else:
+        if len(value) <= DISPLAY_HASH_CHARS * 2:
+            return value
+        head = value[:DISPLAY_HASH_CHARS]
+        return f"{head}..{tail}"
 
 
 def humanize_hash(value: Hash32) -> str:

--- a/eth_utils/humanize.py
+++ b/eth_utils/humanize.py
@@ -86,11 +86,15 @@ DISPLAY_HASH_CHARS = 4
 def humanize_bytes(value: bytes) -> str:
     if len(value) <= DISPLAY_HASH_CHARS + 1:
         return value.hex()
+
     value_as_hex = value.hex()
     return humanize_hex_str(value_as_hex)
 
 
 def humanize_hex_str(value: str) -> str:
+    if len(value) <= DISPLAY_HASH_CHARS * 2:
+        return value
+
     head = value[:DISPLAY_HASH_CHARS]
     tail = value[-1 * DISPLAY_HASH_CHARS :]
     return f"{head}..{tail}"

--- a/eth_utils/humanize.py
+++ b/eth_utils/humanize.py
@@ -87,8 +87,12 @@ def humanize_bytes(value: bytes) -> str:
     if len(value) <= DISPLAY_HASH_CHARS + 1:
         return value.hex()
     value_as_hex = value.hex()
-    head = value_as_hex[:DISPLAY_HASH_CHARS]
-    tail = value_as_hex[-1 * DISPLAY_HASH_CHARS :]
+    return humanize_hex_str(value_as_hex)
+
+
+def humanize_hex_str(value: str) -> str:
+    head = value[:DISPLAY_HASH_CHARS]
+    tail = value[-1 * DISPLAY_HASH_CHARS :]
     return f"{head}..{tail}"
 
 

--- a/newsfragments/285.feature.rst
+++ b/newsfragments/285.feature.rst
@@ -1,0 +1,1 @@
+Add new humanize_hexstr function

--- a/tests/core/humanize-utils/test_humanize_hex_str.py
+++ b/tests/core/humanize-utils/test_humanize_hex_str.py
@@ -1,0 +1,26 @@
+import pytest
+
+from eth_utils import (
+    humanize_hex_str,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (
+            "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "0x00..1e1f",
+        ),
+        (
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "0001..1e1f",
+        ),
+        ("0x30405060", "0x30..5060"),
+        ("0x304050", "0x304050"),
+        ("30060", "30060"),
+        ("0x30060", "0x30060"),
+    ),
+)
+def test_humanize_bytes(value, expected):
+    assert humanize_hex_str(value) == expected

--- a/tests/core/humanize-utils/test_humanize_hexstr.py
+++ b/tests/core/humanize-utils/test_humanize_hexstr.py
@@ -1,7 +1,7 @@
 import pytest
 
 from eth_utils import (
-    humanize_hex_str,
+    humanize_hexstr,
 )
 
 
@@ -10,17 +10,17 @@ from eth_utils import (
     (
         (
             "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
-            "0x00..1e1f",
+            "0x0001..1e1f",
         ),
         (
             "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
             "0001..1e1f",
         ),
-        ("0x30405060", "0x30..5060"),
-        ("0x304050", "0x304050"),
+        ("0x3040506070", "0x3040..6070"),
+        ("0x30405060", "0x30405060"),
         ("30060", "30060"),
         ("0x30060", "0x30060"),
     ),
 )
-def test_humanize_bytes(value, expected):
-    assert humanize_hex_str(value) == expected
+def test_humanize_hexstr(value, expected):
+    assert humanize_hexstr(value) == expected


### PR DESCRIPTION
### What was wrong?
@antazoey had an open PR to add this a while back. I couldn't get the branch to work correctly, so cherry picked the commits and added the ability to pass in a hex string that starts with '0x'. 

Closes #220 

### How was it fixed?
Added a new function called `humanize_hexstr`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.magicmurals.com/media/amasty/webp/catalog/product/cache/155d73b570b90ded8a140526fcb8f2da/D/P/DPX-0002096208_1_jpg.webp)
