### PR TITLE
Remove warning for missing networks

### DIFF
--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -113,22 +113,19 @@ TValue = TypeVar("TValue")
 @overload
 def apply_formatter_if(
     condition: Callable[..., bool]
-) -> Callable[[Callable[..., TReturn]], Callable[[TValue], Union[TReturn, TValue]]]:
-    ...
+) -> Callable[[Callable[..., TReturn]], Callable[[TValue], Union[TReturn, TValue]]]: ...
 
 
 @overload
 def apply_formatter_if(
     condition: Callable[..., bool], formatter: Callable[..., TReturn]
-) -> Callable[[TValue], Union[TReturn, TValue]]:
-    ...
+) -> Callable[[TValue], Union[TReturn, TValue]]: ...
 
 
 @overload
 def apply_formatter_if(
     condition: Callable[..., bool], formatter: Callable[..., TReturn], value: TValue
-) -> Union[TReturn, TValue]:
-    ...
+) -> Union[TReturn, TValue]: ...
 
 
 # This is just a stub to appease mypy, it gets overwritten later
@@ -141,8 +138,7 @@ def apply_formatter_if(
     Callable[[TValue], Union[TReturn, TValue]],
     TReturn,
     TValue,
-]:
-    ...
+]: ...
 
 
 @overload
@@ -150,8 +146,7 @@ def apply_one_of_formatters(
     formatter_condition_pairs: Sequence[
         Tuple[Callable[..., bool], Callable[..., TReturn]]
     ]
-) -> Callable[[TValue], TReturn]:
-    ...
+) -> Callable[[TValue], TReturn]: ...
 
 
 @overload
@@ -160,8 +155,7 @@ def apply_one_of_formatters(
         Tuple[Callable[..., bool], Callable[..., TReturn]]
     ],
     value: TValue,
-) -> TReturn:
-    ...
+) -> TReturn: ...
 
 
 # This is just a stub to appease mypy, it gets overwritten later
@@ -170,70 +164,62 @@ def apply_one_of_formatters(
         Tuple[Callable[..., bool], Callable[..., TReturn]]
     ],
     value: TValue = None,
-) -> TReturn:
-    ...
+) -> TReturn: ...
 
 
 @overload
 def hexstr_if_str(
     to_type: Callable[..., TReturn]
-) -> Callable[[Union[bytes, int, str]], TReturn]:
-    ...
+) -> Callable[[Union[bytes, int, str]], TReturn]: ...
 
 
 @overload
 def hexstr_if_str(
     to_type: Callable[..., TReturn], to_format: Union[bytes, int, str]
-) -> TReturn:
-    ...
+) -> TReturn: ...
 
 
 # This is just a stub to appease mypy, it gets overwritten later
 def hexstr_if_str(
     to_type: Callable[..., TReturn], to_format: Union[bytes, int, str] = None
-) -> TReturn:
-    ...
+) -> TReturn: ...
 
 
 @overload
 def text_if_str(
     to_type: Callable[..., TReturn]
-) -> Callable[[Union[bytes, int, str]], TReturn]:
-    ...
+) -> Callable[[Union[bytes, int, str]], TReturn]: ...
 
 
 @overload
 def text_if_str(
     to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str]
-) -> TReturn:
-    ...
+) -> TReturn: ...
 
 
 # This is just a stub to appease mypy, it gets overwritten later
 def text_if_str(
     to_type: Callable[..., TReturn], text_or_primitive: Union[bytes, int, str] = None
-) -> TReturn:
-    ...
+) -> TReturn: ...
 
 
 @overload
 def apply_formatters_to_dict(
     formatters: Dict[Any, Any]
-) -> Callable[[Dict[Any, Any]], TReturn]:
-    ...
+) -> Callable[[Dict[Any, Any]], TReturn]: ...
 
 
 @overload
 def apply_formatters_to_dict(
     formatters: Dict[Any, Any], value: Dict[Any, Any]
-) -> TReturn:
+) -> TReturn:  # type: ignore
     ...
 
 
 # This is just a stub to appease mypy, it gets overwritten later
 def apply_formatters_to_dict(
     formatters: Dict[Any, Any], value: Optional[Dict[Any, Any]] = None
-) -> TReturn:
+) -> TReturn:  # type: ignore
     ...
 
 

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -85,7 +85,7 @@ def return_arg_type(at_position: int) -> Callable[..., Callable[..., T]]:
 
     def decorator(to_wrap: Callable[..., Any]) -> Callable[..., T]:
         @functools.wraps(to_wrap)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
+        def wrapper(*args: Any, **kwargs: Any) -> T:  # type: ignore
             result = to_wrap(*args, **kwargs)
             ReturnType = type(args[at_position])
             return ReturnType(result)  # type: ignore

--- a/eth_utils/network.py
+++ b/eth_utils/network.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 import json
 import os
 from typing import List
-import warnings
 
 from eth_typing import ChainId
 
@@ -40,12 +39,9 @@ def initialize_network_objects() -> List[Network]:
             )
             networks_obj.append(network)
         except ValueError:
-            # Entry does not have a valid ChainId constant in eth-typing
-            warnings.warn(
-                f"Network {entry['chainId']} with name '{entry['name']}' does not have "
-                f"a valid ChainId. eth-typing should be updated with the latest "
-                f"networks."
-            )
+            # Chain does not have a valid ChainId, network files in eth-utils and
+            # eth-typing should to be updated. Run `python update_networks.py` in the
+            # project root.
             pass
     return networks_obj
 

--- a/eth_utils/numeric.py
+++ b/eth_utils/numeric.py
@@ -6,12 +6,10 @@ from typing import Any, TypeVar, Union
 
 class Comparable(ABC):
     @abstractmethod
-    def __lt__(self, other: Any) -> bool:
-        ...
+    def __lt__(self, other: Any) -> bool: ...
 
     @abstractmethod
-    def __gt__(self, other: Any) -> bool:
-        ...
+    def __gt__(self, other: Any) -> bool: ...
 
 
 TComparable = Union[Comparable, numbers.Real, int, float, decimal.Decimal]

--- a/newsfragments/288.internal.rst
+++ b/newsfragments/288.internal.rst
@@ -1,0 +1,1 @@
+Bump ``mypy`` to ``v0.991`` and fix lint errors

--- a/newsfragments/288.misc.rst
+++ b/newsfragments/288.misc.rst
@@ -1,0 +1,1 @@
+No warning for outdated networks.

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import (
-    setup,
-    find_packages,
-)
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [
@@ -11,12 +8,12 @@ extras_require = {
         "pytest>=7.0.0",
         "pytest-xdist>=2.4.0",
         "types-setuptools",
-        "mypy==0.971",  # mypy does not follow semver, leave it pinned.
+        "mypy==0.991",  # mypy does not follow semver, leave it pinned.
     ],
     "lint": [
         "flake8==3.8.3",  # flake8 claims semver but adds new warnings at minor releases, leave it pinned.
         "isort>=5.11.0",
-        "mypy==0.971",  # mypy does not follow semver, leave it pinned.
+        "mypy==0.991",  # mypy does not follow semver, leave it pinned.
         "pydocstyle>=5.0.0",
         "black>=23",
         "types-setuptools",

--- a/tests/functional-utils/test_type_inference.py
+++ b/tests/functional-utils/test_type_inference.py
@@ -16,7 +16,7 @@ def check_mypy_run(
     cmd_line: List[str],
     expected_out: str,
     expected_err: str = "",
-    expected_returncode: int = 1,
+    expected_returncode: int = 0,
 ) -> None:
     """Helper to run mypy and check the output."""
     out, err, returncode = api.run(cmd_line)

--- a/tests/logging-utils/test_compat_with_abc_ABC.py
+++ b/tests/logging-utils/test_compat_with_abc_ABC.py
@@ -8,8 +8,7 @@ from eth_utils import HasLoggerMeta
 
 class HasLoggerCompatWithABC(metaclass=HasLoggerMeta.meta_compat(ABCMeta)):
     @abstractmethod
-    def something(self):
-        ...
+    def something(self): ...
 
 
 def test_has_logger_compat_with_abc_ABC():


### PR DESCRIPTION
### What was wrong?

Network warnings visible when the network constants are out of date. There is no need to send warnings, especially since the core networks are already present. If a new network is needed, the script can be run separately to update the networks file.

### How was it fixed?

Remove the warning for missing networks and allow initialization from the network list.

### Todo:

- [X] Clean up commit history
- [X] Add or update documentation related to these changes
- [X] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.drewandjonathan.com/wp-content/uploads/2023/10/best-pet-halloween-costumes-960x641.jpg)
