### PR TITLE
refactor(address): accept types AnyAddress, str, bytes

### DIFF
--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -110,7 +110,9 @@ def is_canonical_address(address: Any) -> bool:
     return cast(bool, is_equal)
 
 
-def is_same_address(left: AnyAddress, right: AnyAddress) -> bool:
+def is_same_address(
+    left: Union[AnyAddress, str, bytes], right: Union[AnyAddress, str, bytes]
+) -> bool:
     """
     Checks if both addresses are same or not.
     """

--- a/newsfragments/289.bugfix.rst
+++ b/newsfragments/289.bugfix.rst
@@ -1,0 +1,1 @@
+Update types in `is_same_address` to accept `AnyAddress`, `str`, or `bytes`.


### PR DESCRIPTION
### What was wrong?

The signature of `is_same_address` requires both arguments to be `eth_typing.AnyAddress`, but actually, the source code of the function allows any string to be provided. And mypy raise an error.

Related to Issue #221
Closes #221

### How was it fixed?
For some reason, mypy cannot automatically recognize that bytes correspond to `AnyStr`. This might be related to the fact that `TypeVar` doesn't always work as expected when it comes to type unions. Therefore, I make to `Union[AnyAddress, str, bytes]` instead `Union[AnyAddress, AnyStr]`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="424" alt="image" src="https://github.com/user-attachments/assets/3e800a48-07b8-4b61-ab9d-aa0fbf93dd66">
