### PR TITLE
Add Python 3.13 support; Default to pytoolz after Python 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-core
+  py313-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-core
 
   py38-lint:
     <<: *common
@@ -184,6 +190,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-lint
+  py313-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-lint
 
   py38-wheel:
     <<: *common
@@ -215,6 +227,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-wheel
+  py313-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-wheel
 
   py311-windows-wheel:
     <<: *windows-wheel-setup
@@ -242,6 +260,19 @@ jobs:
       - <<: *run-tox-step
       - <<: *save-cache-step
 
+  py313-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.13'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
+
 define: &all_jobs
   - docs
   - py38-core
@@ -249,18 +280,22 @@ define: &all_jobs
   - py310-core
   - py311-core
   - py312-core
+  - py313-core
   - py38-lint
   - py39-lint
   - py310-lint
   - py311-lint
   - py312-lint
+  - py313-lint
   - py38-wheel
   - py39-wheel
   - py310-wheel
   - py311-wheel
   - py312-wheel
+  - py313-wheel
   - py311-windows-wheel
   - py312-windows-wheel
+  - py313-windows-wheel
 
 workflows:
   version: 2

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,10 @@ setup(
     install_requires=[
         "eth-hash>=0.3.1",
         "eth-typing>=5.0.0",
-        "toolz>0.8.2;implementation_name=='pypy'",
-        "cytoolz>=0.10.1;implementation_name=='cpython'",
+        # cytoolz doesn't have wheels for Python 3.13 yet. See:
+        # https://github.com/pytoolz/cytoolz/issues/209
+        "toolz>0.8.2;implementation_name=='pypy' or python_version>='3.13'",
+        "cytoolz>=0.10.1;implementation_name=='cpython' and python_version<'3.13'",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13 ",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{38,39,310,311,312}-core
-    py{38,39,310,311,312}-lint
-    py{38,39,310,311,312}-wheel
+    py{38,39,310,311,312,313}-core
+    py{38,39,310,311,312,313}-lint
+    py{38,39,310,311,312,313}-wheel
     windows-wheel
     docs
 
@@ -29,6 +29,7 @@ basepython=
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 extras=
     test
     docs
@@ -36,14 +37,14 @@ allowlist_externals=make,pre-commit
 deps=
     eth-hash[pycryptodome]
 
-[testenv:py{38,39,310,311,312}-lint]
+[testenv:py{38,39,310,311,312,313}-lint]
 deps=pre-commit
 extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311,312}-wheel]
+[testenv:py{38,39,310,311,312,313}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?
Cytoolz doesn't have Python 3.13 wheels yet. 

Closes #294 

### How was it fixed?
Added Python 3.13 support here, and don't install cytoolz on Python versions above 3.12. Will watch https://github.com/pytoolz/cytoolz/pull/216 to see if it gets in soon, because then we don't need a hacky workaround. Also worth noting that tests slow significantly with tools vs cytoolz.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
