### PR TITLE
🩹 use `arg.get` in `get_abi_input_names` and `get_abi_output_names`

### DIFF
--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -612,14 +612,14 @@ def get_aligned_abi_inputs(
     )
 
 
-def get_abi_input_names(abi_element: ABIElement) -> List[str | None]:
+def get_abi_input_names(abi_element: ABIElement) -> List[Optional[str]]:
     """
     Return names for each input from the function or event ABI.
 
     :param abi_element: ABI element.
     :type abi_element: `ABIElement`
     :return: Names for each input in the function or event ABI.
-    :rtype: `List[str]`
+    :rtype: `List[Optional[str]]`
 
     .. doctest::
 
@@ -684,14 +684,14 @@ def get_abi_input_types(abi_element: ABIElement) -> List[str]:
     ]
 
 
-def get_abi_output_names(abi_element: ABIElement) -> List[str | None]:
+def get_abi_output_names(abi_element: ABIElement) -> List[Optional[str]]:
     """
     Return names for each output from the ABI element.
 
     :param abi_element: ABI element.
     :type abi_element: `ABIElement`
     :return: Names for each function output in the function ABI.
-    :rtype: `List[str]`
+    :rtype: `List[Optional[str]]`
 
     .. doctest::
 

--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -612,7 +612,7 @@ def get_aligned_abi_inputs(
     )
 
 
-def get_abi_input_names(abi_element: ABIElement) -> List[str]:
+def get_abi_input_names(abi_element: ABIElement) -> List[str | None]:
     """
     Return names for each input from the function or event ABI.
 
@@ -643,7 +643,7 @@ def get_abi_input_names(abi_element: ABIElement) -> List[str]:
     """
     _raise_if_fallback_or_receive_abi(abi_element)
     return [
-        arg["name"]
+        arg.get("name", None)
         for arg in cast(Sequence[ABIComponent], abi_element.get("inputs", []))
     ]
 
@@ -684,7 +684,7 @@ def get_abi_input_types(abi_element: ABIElement) -> List[str]:
     ]
 
 
-def get_abi_output_names(abi_element: ABIElement) -> List[str]:
+def get_abi_output_names(abi_element: ABIElement) -> List[str | None]:
     """
     Return names for each output from the ABI element.
 
@@ -724,7 +724,7 @@ def get_abi_output_names(abi_element: ABIElement) -> List[str]:
     """
     _raise_if_not_function_abi(abi_element)
     return [
-        arg["name"]
+        arg.get("name", None)
         for arg in cast(Sequence[ABIComponent], abi_element.get("outputs", []))
     ]
 

--- a/newsfragments/299.bugfix.rst
+++ b/newsfragments/299.bugfix.rst
@@ -1,0 +1,1 @@
+Replace ``arg["name"]`` with ``arg.get("name")`` to correctly handle optional names.


### PR DESCRIPTION
### What was wrong?
Raised `KeyError` exception when `name` field not in `ABIComponent`

Related to Issue #297
Closes #297

### How was it fixed?
Replace `arg["name"]` with `arg.get("name")`

And I think we need to update `ABIElement` in `eth-typing` because names are optional

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/09ad085c-7c27-4530-8a82-ca63669fcebc)
