### PR TITLE
Add CamelModel pydantic model for use across libraries

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -207,8 +207,8 @@ the same type as it was supplied. For example:
     >>> list_formatter((1.2, 3.4, 5.6, 7.8))
     (True, 3, '5.6', 7.8)
 
-``apply_formatters_to_dict(formatter_dict, <dict_like>)`` -> dict
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``apply_formatters_to_dict(formatter_dict, <dict_like>, unaliased=False)`` -> dict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This function will apply the formatter to the element with the matching
 key in ``dict_like``, passing through values with keys that have no
@@ -230,6 +230,34 @@ matching formatter.
     ... })
     >>> result == {'should_be_int': 1, 'should_be_bool': True, 'pass_through': 5.6}
     True
+
+The ``CamelModel`` pydantic model is included in expected dict-like types. If the
+dict-like object is an instance of a ``CamelModel``, the ``unaliased`` argument
+can be set to ``True`` to pre-serialize the object as "non-aliased", according to
+pydantic. By default, it will be pre-serialized as "aliased", which ``CamelModel``
+interprets as camelCase keys.
+
+.. doctest::
+
+    >>> from eth_utils.curried import apply_formatters_to_dict
+    >>> from eth_utils import CamelModel, to_bytes, to_int
+    >>> from pydantic import Field
+
+    >>> class PydanticModel(CamelModel):
+    ...     to_bytes_from_int: int = 1
+    ...     to_int_from_bytes: bytes = b"\x02"
+    ...     # class fields excluded from serialization
+    ...     excluded_field: int = Field(default=3, exclude=True)
+    ...     excluded_field_two: str = Field(default="4", exclude=True)
+
+    >>> dict_formatter = apply_formatters_to_dict({
+    ...     "toBytesFromInt": to_bytes,
+    ...     "toIntFromBytes": to_int
+    ... })
+
+    >>> dict_formatter(PydanticModel())
+    {'toBytesFromInt': b'\x01', 'toIntFromBytes': 2}
+
 
 ``apply_key_map(formatter_dict, <dict_like>)`` -> dict
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/eth_utils/__init__.py
+++ b/eth_utils/__init__.py
@@ -122,6 +122,9 @@ from .network import (
 from .numeric import (
     clamp,
 )
+from .pydantic import (
+    CamelModel,
+)
 from .types import (
     is_boolean,
     is_bytes,

--- a/eth_utils/applicators.py
+++ b/eth_utils/applicators.py
@@ -5,6 +5,7 @@ from typing import (
     Generator,
     List,
     Tuple,
+    Union,
 )
 import warnings
 
@@ -13,6 +14,9 @@ from .decorators import (
 )
 from .functional import (
     to_dict,
+)
+from .pydantic import (
+    CamelModel,
 )
 from .toolz import (
     compose,
@@ -89,8 +93,24 @@ def apply_formatter_if(
 
 @to_dict
 def apply_formatters_to_dict(
-    formatters: Dict[Any, Any], value: Dict[Any, Any]
+    formatters: Dict[Any, Any],
+    value: Union[Dict[Any, Any], CamelModel],
+    unaliased: bool = False,
 ) -> Generator[Tuple[Any, Any], None, None]:
+    """
+    Apply formatters to a dictionary of values. If the value is a pydantic model,
+    it will be serialized to a dictionary first, taking into account the
+    ``unaliased`` parameter.
+
+    :param formatters: The formatters to apply to the dictionary.
+    :param value: The dictionary-like object to apply the formatters to.
+    :param unaliased: If the model is a ``CamelModel``, whether to turn off
+        serialization by alias (camelCase).
+    :return: A generator that yields the formatted key-value pairs.
+    """
+    if isinstance(value, CamelModel):
+        value = value.model_dump(by_alias=not unaliased)
+
     for key, item in value.items():
         if key in formatters:
             try:

--- a/eth_utils/curried/__init__.py
+++ b/eth_utils/curried/__init__.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from eth_utils import (
+    CamelModel,
     ExtendedDebugLogger,
     HasExtendedDebugLogger,
     HasExtendedDebugLoggerMeta,
@@ -121,7 +122,7 @@ TValue = TypeVar("TValue")
 
 @overload
 def apply_formatter_if(
-    condition: Callable[..., bool]
+    condition: Callable[..., bool],
 ) -> Callable[[Callable[..., TReturn]], Callable[[TValue], Union[TReturn, TValue]]]:
     pass
 
@@ -158,7 +159,7 @@ def apply_formatter_if(  # type: ignore
 def apply_one_of_formatters(
     formatter_condition_pairs: Sequence[
         Tuple[Callable[..., bool], Callable[..., TReturn]]
-    ]
+    ],
 ) -> Callable[[TValue], TReturn]:
     ...
 
@@ -185,7 +186,7 @@ def apply_one_of_formatters(  # type: ignore
 
 @overload
 def hexstr_if_str(
-    to_type: Callable[..., TReturn]
+    to_type: Callable[..., TReturn],
 ) -> Callable[[Union[bytes, int, str]], TReturn]:
     ...
 
@@ -206,7 +207,7 @@ def hexstr_if_str(  # type: ignore
 
 @overload
 def text_if_str(
-    to_type: Callable[..., TReturn]
+    to_type: Callable[..., TReturn],
 ) -> Callable[[Union[bytes, int, str]], TReturn]:
     ...
 
@@ -228,21 +229,23 @@ def text_if_str(  # type: ignore
 
 @overload
 def apply_formatters_to_dict(
-    formatters: Dict[Any, Any]
+    formatters: Dict[Any, Any], unaliased: bool = False
 ) -> Callable[[Dict[Any, Any]], TReturn]:
     ...
 
 
 @overload
 def apply_formatters_to_dict(
-    formatters: Dict[Any, Any], value: Dict[Any, Any]
+    formatters: Dict[Any, Any], value: Union[Dict[Any, Any], CamelModel]
 ) -> Dict[Any, Any]:
     ...
 
 
 # This is just a stub to appease mypy, it gets overwritten later
 def apply_formatters_to_dict(  # type: ignore
-    formatters: Dict[Any, Any], value: Optional[Dict[Any, Any]] = None
+    formatters: Dict[Any, Any],
+    value: Optional[Union[Dict[Any, Any], CamelModel]] = None,
+    unaliased: bool = False,
 ) -> Dict[Any, Any]:
     ...
 

--- a/eth_utils/pydantic.py
+++ b/eth_utils/pydantic.py
@@ -1,0 +1,101 @@
+from typing import (
+    Any,
+    Dict,
+    Type,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+)
+from pydantic._internal._core_utils import (
+    CoreSchemaField,
+)
+from pydantic.alias_generators import (
+    to_camel,
+)
+from pydantic.json_schema import (
+    DEFAULT_REF_TEMPLATE,
+    GenerateJsonSchema,
+    JsonSchemaMode,
+)
+
+
+class OmitJsonSchema(GenerateJsonSchema):
+    """
+    Custom JSON schema generator that omits the schema generation for fields that are
+    invalid. Excluded fields (``Field(exclude=True)``) are generally useful as
+    properties of the model but are not meant to be serialized to JSON.
+    """
+
+    def field_is_present(self, field: CoreSchemaField) -> bool:
+        # override ``field_is_present`` and omit excluded fields from the schema
+        if field.get("serialization_exclude", False):
+            return False
+        return super().field_is_present(field)
+
+
+class CamelModel(BaseModel):
+    """
+    Camel-case pydantic model. This model is used to ensure serialization in a
+    consistent manner, aliasing as camelCase serialization. This is useful for models
+    that are used in JSON-RPC requests and responses, marking useful fields for the
+    model, but that are not part of the JSON-RPC object, with ``Field(exclude=True)``.
+    To serialize a model to the expected JSON-RPC format, or camelCase, use
+    ``model_dump(by_alias=True)``.
+
+    .. code-block:: python
+
+        >>> from eth_utils.pydantic import CamelModel
+        >>> from pydantic import Field
+
+        >>> class SignedSetCodeAuthorization(CamelModel):
+        ...     chain_id: int
+        ...     address: bytes
+        ...     nonce: int
+        ...
+        ...     # useful fields for the object but excluded from serialization
+        ...     # (not part of the JSON-RPC object)
+        ...     authorization_hash: bytes = Field(exclude=True)
+        ...     signature: bytes = Field(exclude=True)
+
+        >>> auth = SignedSetCodeAuthorization(
+        ...     chain_id=1,
+        ...     address=b"0x0000000000000000000000000000000000000000",
+        ...     nonce=0,
+        ...     authorization_hash=generated_hash,
+        ...     signature=generated_signature,
+        ... )
+        >>> auth.model_dump(by_alias=True)
+        {'chainId': 1, 'address': '0x000000000000000000000000000000000000', 'nonce': 0}
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        # populate by snake_case (python) args
+        populate_by_name=True,
+        # serialize by camelCase (json-rpc) keys
+        alias_generator=to_camel,
+        # validate default values
+        validate_default=True,
+    )
+
+    @classmethod
+    def model_json_schema(
+        cls,
+        by_alias: bool = True,
+        ref_template: str = DEFAULT_REF_TEMPLATE,
+        # default to ``OmitJsonSchema`` to prevent errors from excluded fields
+        schema_generator: Type[GenerateJsonSchema] = OmitJsonSchema,
+        mode: JsonSchemaMode = "validation",
+    ) -> Dict[str, Any]:
+        """
+        Omits excluded fields from the JSON schema, preventing errors that would
+        otherwise be raised by the default schema generator.
+        """
+        return super().model_json_schema(
+            by_alias=by_alias,
+            ref_template=ref_template,
+            schema_generator=schema_generator,
+            mode=mode,
+        )

--- a/newsfragments/303.feature.rst
+++ b/newsfragments/303.feature.rst
@@ -1,0 +1,1 @@
+Add ``CamelModel`` pydantic model for validating objects and serializing to camelCase when used with ``by_alias=True``, with the general expectation of a well-formed JSON-RPC object.

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "eth-typing>=5.0.0",
         "toolz>0.8.2;implementation_name=='pypy'",
         "cytoolz>=0.10.1;implementation_name=='cpython'",
+        "pydantic>=2.0.0,<3",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/tests/core/pydantic-utils/test_camel_model.py
+++ b/tests/core/pydantic-utils/test_camel_model.py
@@ -1,0 +1,78 @@
+from pydantic import (
+    Field,
+)
+
+from eth_utils.pydantic import (
+    CamelModel,
+)
+
+
+class PydanticTestClass(CamelModel):
+    field_five: int = 5
+    field_six: str = "6"
+    field_seven: str = Field(default="7", exclude=True)
+    field_eight: int = Field(default=8, exclude=True)
+
+
+class NestedPydanticTestClass(CamelModel):
+    field_one: int = 1
+    field_two: str = "2"
+    field_three: str = Field(default="3", exclude=True)
+    field_four: PydanticTestClass = PydanticTestClass()
+
+
+def test_camel_model_dump():
+    dump_alias = PydanticTestClass().model_dump(by_alias=True)
+    dump = PydanticTestClass().model_dump()
+    assert dump_alias == {"fieldFive": 5, "fieldSix": "6"}
+    assert dump == {"field_five": 5, "field_six": "6"}
+
+    dump_alias_nested = NestedPydanticTestClass().model_dump(by_alias=True)
+    dump_nested = NestedPydanticTestClass().model_dump()
+    assert dump_alias_nested == {
+        "fieldOne": 1,
+        "fieldTwo": "2",
+        "fieldFour": {"fieldFive": 5, "fieldSix": "6"},
+    }
+    assert dump_nested == {
+        "field_one": 1,
+        "field_two": "2",
+        "field_four": {"field_five": 5, "field_six": "6"},
+    }
+
+
+def test_camel_model_json_schema():
+    schema = PydanticTestClass().model_json_schema(by_alias=True)
+    assert isinstance(schema, dict)
+    properties = schema["properties"]
+    assert len(properties) == 2
+    assert all(field in properties for field in {"fieldFive", "fieldSix"})
+    assert "fieldSix" in properties
+    field_5_props = {"title": "Fieldfive", "type": "integer", "default": 5}
+    assert properties["fieldFive"] == field_5_props
+    field_6_props = {"title": "Fieldsix", "type": "string", "default": "6"}
+    assert properties["fieldSix"] == field_6_props
+
+    schema_nested = NestedPydanticTestClass().model_json_schema(by_alias=True)
+    assert isinstance(schema_nested, dict)
+    properties_nested = schema_nested["properties"]
+    assert len(properties_nested) == 3
+    assert all(
+        field in properties_nested for field in {"fieldOne", "fieldTwo", "fieldFour"}
+    )
+    assert properties_nested["fieldOne"] == {
+        "title": "Fieldone",
+        "type": "integer",
+        "default": 1,
+    }
+    assert properties_nested["fieldTwo"] == {
+        "title": "Fieldtwo",
+        "type": "string",
+        "default": "2",
+    }
+    assert properties_nested["fieldFour"] == {
+        "$ref": "#/$defs/PydanticTestClass",
+        "default": {"fieldFive": 5, "fieldSix": "6"},
+    }
+    # assert the reference to the nested model properties
+    assert schema_nested["$defs"]["PydanticTestClass"]["properties"] == properties


### PR DESCRIPTION
### What was wrong?

Related to Issues:

- Moves the work done in ethereum/eth-account#316 ethereum/eth-account#318 to *eth-utils* for standardization / use across ethereum python libraries.
- These changes allow expected validated pydantic models (`CamelModel`) to be serialized to JSON-RPC expected types when appropriate.
- Since JSON-RPC objects could be `CamelModel` classes, open the expected types to allow for this model in ``apply_formatters_to_dict()``.

Beyond this PR, `eth-account` should be updated to use this model, making sure no breaking changes are introduced, so that those models are not excluded from any class checks across our repos.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

I'm not sure if an animal that formats other animals with a computer is cute... I think this is terrifying in a way 😬 . Thanks, chatGPT.

<img width="477" alt="Screenshot 2025-04-11 at 12 04 15" src="https://github.com/user-attachments/assets/43ad11a6-97a1-4d56-933f-56f6f67cdbb1" />

