### PR TITLE
fix(mypy): fix type hints for get_normalized_abi_inputs

### DIFF
--- a/eth_utils/abi.py
+++ b/eth_utils/abi.py
@@ -439,8 +439,8 @@ def get_all_event_abis(contract_abi: ABI) -> Sequence[ABIEvent]:
 
 def get_normalized_abi_inputs(
     abi_element: ABIElement,
-    *args: Optional[Sequence[Any]],
-    **kwargs: Optional[Dict[str, Any]],
+    *args: Any,
+    **kwargs: Any,
 ) -> Tuple[Any, ...]:
     r"""
     Flattens positional args (``args``) and keyword args (``kwargs``) into a Tuple and
@@ -505,7 +505,7 @@ def get_normalized_abi_inputs(
 
     # If no keyword args were given, we don't need to align them
     if not kwargs:
-        return cast(Tuple[Any, ...], args)
+        return args
 
     kwarg_names = set(kwargs.keys())
     sorted_arg_names = tuple(arg_abi["name"] for arg_abi in function_inputs)


### PR DESCRIPTION
### What was wrong?

`get_normalized_abi_inputs` has incorrect type hints, which this PR fixes

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpapers.com/images/featured/cute-bat-pictures-knr84v92kcgieakq.webp)
