### PR TITLE
typing: add TypeGuard returns to type predicates

### DIFF
--- a/eth_utils/address.py
+++ b/eth_utils/address.py
@@ -1,7 +1,7 @@
 import re
 from typing import (
     Any,
-    cast,
+    TypeGuard,
 )
 
 from eth_typing import (
@@ -33,7 +33,7 @@ from .types import (
 _HEX_ADDRESS_REGEXP = re.compile("(0x)?[0-9a-f]{40}", re.IGNORECASE | re.ASCII)
 
 
-def is_hex_address(value: Any) -> bool:
+def is_hex_address(value: Any) -> TypeGuard[HexAddress]:
     """
     Checks if the given string of text type is an address in hexadecimal encoded form.
     """
@@ -42,7 +42,7 @@ def is_hex_address(value: Any) -> bool:
     return _HEX_ADDRESS_REGEXP.fullmatch(value) is not None
 
 
-def is_binary_address(value: Any) -> bool:
+def is_binary_address(value: Any) -> TypeGuard[Address]:
     """
     Checks if the given string is an address in raw bytes form.
     """
@@ -81,7 +81,7 @@ def to_normalized_address(value: AnyAddress | str | bytes) -> HexAddress:
         )
 
 
-def is_normalized_address(value: Any) -> bool:
+def is_normalized_address(value: Any) -> TypeGuard[HexAddress]:
     """
     Returns whether the provided value is an address in its normalized form.
     """
@@ -89,7 +89,7 @@ def is_normalized_address(value: Any) -> bool:
         return False
     else:
         is_equal = value == to_normalized_address(value)
-        return cast(bool, is_equal)
+        return bool(is_equal)
 
 
 def to_canonical_address(address: AnyAddress | str | bytes) -> Address:
@@ -99,14 +99,14 @@ def to_canonical_address(address: AnyAddress | str | bytes) -> Address:
     return Address(decode_hex(to_normalized_address(address)))
 
 
-def is_canonical_address(address: Any) -> bool:
+def is_canonical_address(address: Any) -> TypeGuard[Address]:
     """
     Returns `True` if the `value` is an address in its canonical form.
     """
     if not is_bytes(address) or len(address) != 20:
         return False
     is_equal = address == to_canonical_address(address)
-    return cast(bool, is_equal)
+    return is_equal
 
 
 def is_same_address(
@@ -143,14 +143,14 @@ def to_checksum_address(value: AnyAddress | str | bytes) -> ChecksumAddress:
     return ChecksumAddress(HexAddress(checksum_address))
 
 
-def is_checksum_address(value: Any) -> bool:
+def is_checksum_address(value: Any) -> TypeGuard[ChecksumAddress]:
     if not is_text(value):
         return False
 
     if not is_hex_address(value):
         return False
     is_equal = value == to_checksum_address(value)
-    return cast(bool, is_equal)
+    return is_equal
 
 
 def _is_checksum_formatted(value: Any) -> bool:

--- a/eth_utils/conversions.py
+++ b/eth_utils/conversions.py
@@ -70,7 +70,7 @@ def to_hex(
         )
 
     if is_integer(primitive):
-        return HexStr(hex(cast(int, primitive)))
+        return HexStr(hex(primitive))
 
     raise TypeError(
         f"Unsupported type: '{repr(type(primitive))}'. Must be one of: bool, str, "
@@ -158,7 +158,7 @@ def to_text(
     elif isinstance(primitive, memoryview):
         return bytes(primitive).decode("utf-8")
     elif is_integer(primitive):
-        byte_encoding = int_to_big_endian(cast(int, primitive))
+        byte_encoding = int_to_big_endian(primitive)
         return to_text(byte_encoding)
     raise TypeError("Expected an int, bytes, bytearray or hexstr.")
 

--- a/eth_utils/hexadecimal.py
+++ b/eth_utils/hexadecimal.py
@@ -5,6 +5,7 @@ import re
 from typing import (
     Any,
     AnyStr,
+    TypeGuard,
 )
 
 from eth_typing import (
@@ -60,13 +61,13 @@ def add_0x_prefix(value: HexStr) -> HexStr:
     return HexStr("0x" + value)
 
 
-def is_hexstr(value: Any) -> bool:
+def is_hexstr(value: Any) -> TypeGuard[HexStr]:
     if not is_text(value) or not value:
         return False
     return _HEX_REGEXP.fullmatch(value) is not None
 
 
-def is_hex(value: Any) -> bool:
+def is_hex(value: Any) -> TypeGuard[HexStr]:
     if not is_text(value):
         raise TypeError(f"is_hex requires text typed arguments. Got: {repr(value)}")
     if not value:

--- a/eth_utils/types.py
+++ b/eth_utils/types.py
@@ -2,6 +2,7 @@ import collections.abc
 import numbers
 from typing import (
     Any,
+    TypeGuard,
 )
 
 bytes_types = (bytes, bytearray)
@@ -10,15 +11,15 @@ text_types = (str,)
 string_types = (bytes, str, bytearray)
 
 
-def is_integer(value: Any) -> bool:
+def is_integer(value: Any) -> TypeGuard[int]:
     return isinstance(value, integer_types) and not isinstance(value, bool)
 
 
-def is_bytes(value: Any) -> bool:
+def is_bytes(value: Any) -> TypeGuard[bytes | bytearray]:
     return isinstance(value, bytes_types)
 
 
-def is_text(value: Any) -> bool:
+def is_text(value: Any) -> TypeGuard[str]:
     return isinstance(value, text_types)
 
 
@@ -26,29 +27,29 @@ def is_string(value: Any) -> bool:
     return isinstance(value, string_types)
 
 
-def is_boolean(value: Any) -> bool:
+def is_boolean(value: Any) -> TypeGuard[bool]:
     return isinstance(value, bool)
 
 
-def is_dict(obj: Any) -> bool:
+def is_dict(obj: Any) -> TypeGuard[collections.abc.Mapping[Any, Any]]:
     return isinstance(obj, collections.abc.Mapping)
 
 
-def is_list_like(obj: Any) -> bool:
+def is_list_like(obj: Any) -> TypeGuard[collections.abc.Sequence[Any]]:
     return not is_string(obj) and isinstance(obj, collections.abc.Sequence)
 
 
-def is_list(obj: Any) -> bool:
+def is_list(obj: Any) -> TypeGuard[list[Any]]:
     return isinstance(obj, list)
 
 
-def is_tuple(obj: Any) -> bool:
+def is_tuple(obj: Any) -> TypeGuard[tuple[Any, ...]]:
     return isinstance(obj, tuple)
 
 
-def is_null(obj: Any) -> bool:
+def is_null(obj: Any) -> TypeGuard[None]:
     return obj is None
 
 
-def is_number(obj: Any) -> bool:
+def is_number(obj: Any) -> TypeGuard[numbers.Number]:
     return isinstance(obj, numbers.Number)

--- a/tests/mypy/type_predicates.py
+++ b/tests/mypy/type_predicates.py
@@ -1,0 +1,78 @@
+from collections.abc import (
+    Mapping,
+    Sequence,
+)
+import numbers
+from typing import (
+    Any,
+)
+
+from eth_typing import (
+    Address,
+    ChecksumAddress,
+    HexAddress,
+    HexStr,
+)
+
+from eth_utils import (
+    is_binary_address,
+    is_boolean,
+    is_bytes,
+    is_canonical_address,
+    is_checksum_address,
+    is_dict,
+    is_hex,
+    is_hex_address,
+    is_hexstr,
+    is_integer,
+    is_list,
+    is_list_like,
+    is_normalized_address,
+    is_null,
+    is_number,
+    is_text,
+    is_tuple,
+)
+
+
+def check_type_predicates(value: object) -> None:
+    if is_integer(value):
+        integer_value: int = value  # noqa: F841
+    if is_bytes(value):
+        bytes_value: bytes | bytearray = value  # noqa: F841
+    if is_text(value):
+        text_value: str = value  # noqa: F841
+    if is_boolean(value):
+        boolean_value: bool = value  # noqa: F841
+    if is_dict(value):
+        mapping_value: Mapping[Any, Any] = value  # noqa: F841
+    if is_list_like(value):
+        sequence_value: Sequence[Any] = value  # noqa: F841
+    if is_list(value):
+        list_value: list[Any] = value  # noqa: F841
+    if is_tuple(value):
+        tuple_value: tuple[Any, ...] = value  # noqa: F841
+    if is_null(value):
+        null_value: None = value  # noqa: F841
+    if is_number(value):
+        number_value: numbers.Number = value  # noqa: F841
+
+
+def check_address_predicates(value: object) -> None:
+    if is_hex_address(value):
+        hex_address_value: HexAddress = value  # noqa: F841
+    if is_binary_address(value):
+        binary_address_value: Address = value  # noqa: F841
+    if is_normalized_address(value):
+        normalized_address_value: HexAddress = value  # noqa: F841
+    if is_canonical_address(value):
+        canonical_address_value: Address = value  # noqa: F841
+    if is_checksum_address(value):
+        checksum_address_value: ChecksumAddress = value  # noqa: F841
+
+
+def check_hex_predicates(value: object) -> None:
+    if is_hexstr(value):
+        hexstr_value: HexStr = value  # noqa: F841
+    if is_hex(value):
+        hex_value: HexStr = value  # noqa: F841


### PR DESCRIPTION
Improve downstream type narrowing for existing predicate helpers without changing their runtime validation behavior.

### What was wrong?

Predicate helpers returned plain `bool`, so downstream type checkers could not narrow values after successful runtime checks.

Related to Issue #
Closes #

### How was it fixed?

Added safe `TypeGuard` return annotations to existing type, address, and hexadecimal predicates. Runtime bodies are unchanged, and a mypy fixture proves the expected narrowing.

### Todo:

- [x] Clean up commit history
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Cute kitten](https://commons.wikimedia.org/wiki/Special:Redirect/file/Cute_kitten!.jpg)