### PR TITLE
perf: cache decorator factories

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -5,7 +5,10 @@ import functools
 import itertools
 from typing import (
     Any,
+    Final,
+    TypeAlias,
     TypeVar,
+    cast,
 )
 
 from .types import (
@@ -13,6 +16,14 @@ from .types import (
 )
 
 T = TypeVar("T")
+
+Decorator: TypeAlias = Callable[[Callable[..., Any]], Callable[..., Any]]
+ExcType: TypeAlias = type[BaseException]
+ExceptionMap: TypeAlias = dict[ExcType, ExcType]
+ExceptionMapCacheKey: TypeAlias = tuple[int, tuple[tuple[ExcType, ExcType], ...]]
+
+_RETURN_ARG_TYPE_CACHE: Final[dict[int, Decorator]] = {}
+_REPLACE_EXCEPTIONS_CACHE: Final[dict[ExceptionMapCacheKey, Decorator]] = {}
 
 
 class combomethod:
@@ -92,6 +103,10 @@ def return_arg_type(at_position: int) -> Callable[..., Callable[..., T]]:
     """
     Wrap the return value with the result of `type(args[at_position])`.
     """
+    if at_position in _RETURN_ARG_TYPE_CACHE:
+        return cast(
+            Callable[..., Callable[..., T]], _RETURN_ARG_TYPE_CACHE[at_position]
+        )
 
     def decorator(to_wrap: Callable[..., Any]) -> Callable[..., T]:
         @functools.wraps(to_wrap)
@@ -102,15 +117,29 @@ def return_arg_type(at_position: int) -> Callable[..., Callable[..., T]]:
 
         return wrapper
 
+    _RETURN_ARG_TYPE_CACHE[at_position] = decorator
     return decorator
 
 
+def _make_exception_map_cache_key(
+    old_to_new_exceptions: ExceptionMap,
+) -> ExceptionMapCacheKey:
+    return (id(old_to_new_exceptions), tuple(old_to_new_exceptions.items()))
+
+
 def replace_exceptions(
-    old_to_new_exceptions: dict[type[BaseException], type[BaseException]]
+    old_to_new_exceptions: ExceptionMap,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     Replaces old exceptions with new exceptions to be raised in their place.
     """
+    cache_key = _make_exception_map_cache_key(old_to_new_exceptions)
+    if cache_key in _REPLACE_EXCEPTIONS_CACHE:
+        return cast(
+            Callable[[Callable[..., T]], Callable[..., T]],
+            _REPLACE_EXCEPTIONS_CACHE[cache_key],
+        )
+
     old_exceptions = tuple(old_to_new_exceptions.keys())
 
     def decorator(to_wrap: Callable[..., T]) -> Callable[..., T]:
@@ -128,4 +157,5 @@ def replace_exceptions(
 
         return wrapped
 
+    _REPLACE_EXCEPTIONS_CACHE[cache_key] = decorator
     return decorator

--- a/tests/core/decorator-utils/test_replace_exceptions.py
+++ b/tests/core/decorator-utils/test_replace_exceptions.py
@@ -3,6 +3,9 @@ import pytest
 from eth_utils import (
     replace_exceptions,
 )
+from eth_utils.decorators import (
+    return_arg_type,
+)
 
 
 @pytest.fixture()
@@ -25,3 +28,43 @@ def mock_function_with_exception(old_to_new):
 def test_decorator_replaces_exceptions(mock_function_with_exception, old_to_new, new):
     with pytest.raises(new, match="Boom!"):
         mock_function_with_exception(old_to_new)
+
+
+def test_return_arg_type_reuses_matching_factory():
+    assert return_arg_type(1) is return_arg_type(1)
+    assert return_arg_type(1) is not return_arg_type(2)
+
+
+def test_replace_exceptions_reuses_matching_factory_for_same_mapping():
+    old_to_new = {TypeError: AttributeError}
+
+    assert replace_exceptions(old_to_new) is replace_exceptions(old_to_new)
+
+
+def test_replace_exceptions_does_not_share_factories_across_mappings():
+    old_to_new = {TypeError: AttributeError}
+    other_old_to_new = {TypeError: AttributeError}
+
+    assert replace_exceptions(old_to_new) is not replace_exceptions(other_old_to_new)
+
+
+def test_replace_exceptions_rebuilds_when_mapping_changes():
+    old_to_new = {TypeError: AttributeError}
+    first = replace_exceptions(old_to_new)
+
+    old_to_new[ValueError] = NameError
+
+    assert first is not replace_exceptions(old_to_new)
+
+
+def test_replace_exceptions_preserves_mutable_mapping_behavior():
+    old_to_new = {TypeError: AttributeError}
+    decorator = replace_exceptions(old_to_new)
+    old_to_new[TypeError] = NameError
+
+    @decorator
+    def function_with_exception():
+        raise TypeError("Boom!")
+
+    with pytest.raises(NameError, match="Boom!"):
+        function_with_exception()


### PR DESCRIPTION
Reuse repeated decorator factory results without changing decorator behavior.

### What was wrong?

`return_arg_type()` and `replace_exceptions()` rebuilt equivalent decorator factories on repeated calls.

Related to Issue #
Closes #

### How was it fixed?

Added small caches for repeated factory calls. The exception factory cache keys on mapping identity plus current items, preserving existing mutable mapping behavior. Tests cover reuse and mutation cases.

### Todo:

- [x] Clean up commit history
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Red panda](https://commons.wikimedia.org/wiki/Special:Redirect/file/The_red_panda.jpg)