### PR TITLE
typing: preserve functional decorator signatures

### DIFF
--- a/eth_utils/functional.py
+++ b/eth_utils/functional.py
@@ -2,7 +2,6 @@ import collections
 from collections.abc import (
     Callable,
     Iterable,
-    Mapping,
 )
 import functools
 import itertools
@@ -10,6 +9,7 @@ from typing import (  # noqa: F401
     Any,
     Dict,
     List,
+    ParamSpec,
     Set,
     Tuple,
     TypeVar,
@@ -21,6 +21,8 @@ from .toolz import (
 )
 
 T = TypeVar("T")
+TReturn = TypeVar("TReturn")
+P = ParamSpec("P")
 
 
 def identity(value: T) -> T:
@@ -39,13 +41,11 @@ def combine(
 
 
 def apply_to_return_value(
-    callback: Callable[..., T]
-) -> Callable[..., Callable[..., T]]:
-    def outer(fn: Callable[..., T]) -> Callable[..., T]:
-        # We would need to type annotate *args and **kwargs but doing so segfaults
-        # the PyPy builds. We ignore instead.
+    callback: Callable[[T], TReturn],
+) -> Callable[[Callable[P, T]], Callable[P, TReturn]]:
+    def outer(fn: Callable[P, T]) -> Callable[P, TReturn]:
         @functools.wraps(fn)
-        def inner(*args, **kwargs) -> T:  # type: ignore
+        def inner(*args: P.args, **kwargs: P.kwargs) -> TReturn:
             return callback(fn(*args, **kwargs))
 
         return inner
@@ -55,23 +55,52 @@ def apply_to_return_value(
 
 TVal = TypeVar("TVal")
 TKey = TypeVar("TKey")
-to_tuple: Callable[
-    [Callable[..., Iterable[TVal]]], Callable[..., tuple[TVal, ...]]
-] = apply_to_return_value(tuple)
-to_list: Callable[
-    [Callable[..., Iterable[TVal]]], Callable[..., list[TVal]]
-] = apply_to_return_value(list)
-to_set: Callable[
-    [Callable[..., Iterable[TVal]]], Callable[..., set[TVal]]
-] = apply_to_return_value(set)
-to_dict: Callable[
-    [Callable[..., Iterable[Mapping[TKey, TVal] | tuple[TKey, TVal]]]],
-    Callable[..., dict[TKey, TVal]],
-] = apply_to_return_value(dict)
-to_ordered_dict: Callable[
-    [Callable[..., Iterable[Mapping[TKey, TVal] | tuple[TKey, TVal]]]],
-    Callable[..., collections.OrderedDict[TKey, TVal]],
-] = apply_to_return_value(collections.OrderedDict)
+
+
+def to_tuple(fn: Callable[P, Iterable[TVal]]) -> Callable[P, tuple[TVal, ...]]:
+    @functools.wraps(fn)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> tuple[TVal, ...]:
+        return tuple(fn(*args, **kwargs))
+
+    return inner
+
+
+def to_list(fn: Callable[P, Iterable[TVal]]) -> Callable[P, list[TVal]]:
+    @functools.wraps(fn)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> list[TVal]:
+        return list(fn(*args, **kwargs))
+
+    return inner
+
+
+def to_set(fn: Callable[P, Iterable[TVal]]) -> Callable[P, set[TVal]]:
+    @functools.wraps(fn)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> set[TVal]:
+        return set(fn(*args, **kwargs))
+
+    return inner
+
+
+def to_dict(
+    fn: Callable[P, Iterable[tuple[TKey, TVal]]],
+) -> Callable[P, dict[TKey, TVal]]:
+    @functools.wraps(fn)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> dict[TKey, TVal]:
+        return dict(fn(*args, **kwargs))
+
+    return inner
+
+
+def to_ordered_dict(
+    fn: Callable[P, Iterable[tuple[TKey, TVal]]],
+) -> Callable[P, collections.OrderedDict[TKey, TVal]]:
+    @functools.wraps(fn)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> collections.OrderedDict[TKey, TVal]:
+        return collections.OrderedDict(fn(*args, **kwargs))
+
+    return inner
+
+
 sort_return = _compose(to_tuple, apply_to_return_value(sorted))
 flatten_return = _compose(
     to_tuple, apply_to_return_value(itertools.chain.from_iterable)

--- a/tests/mypy/functional_decorator_inference.py
+++ b/tests/mypy/functional_decorator_inference.py
@@ -1,0 +1,39 @@
+# no-unused-vars
+from typing import (
+    Protocol,
+)
+
+from eth_utils import (
+    apply_to_return_value,
+    to_tuple,
+)
+
+
+class CountFormatter(Protocol):
+    def __call__(self, name: str, count: int, *, enabled: bool = True) -> list[int]:
+        ...
+
+
+class TupleFormatter(Protocol):
+    def __call__(self, prefix: str, total: int) -> tuple[str, ...]:
+        ...
+
+
+def wrap_count(value: int) -> list[int]:
+    return [value]
+
+
+@apply_to_return_value(wrap_count)
+def count_items(name: str, count: int, *, enabled: bool = True) -> int:
+    return count if enabled else 0
+
+
+@to_tuple
+def generate_values(prefix: str, total: int) -> list[str]:
+    return [prefix for _ in range(total)]
+
+
+formatted_count: CountFormatter = count_items
+formatted_tuple: TupleFormatter = generate_values
+count_result: list[int] = count_items("items", 3, enabled=False)
+tuple_result: tuple[str, ...] = generate_values("item", 3)


### PR DESCRIPTION
Preserve decorated callable signatures for functional return-value helpers.

### What was wrong?

Return-value decorators refined return types but erased wrapped function argument signatures for type checkers.

Related to Issue #
Closes #

### How was it fixed?

Updated the functional decorators to use `ParamSpec`, preserving callable parameters while refining return types. Wrapper metadata is still preserved with `functools.wraps`, and mypy coverage verifies the improved inference.

### Todo:

- [x] Clean up commit history
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Cute rabbit](https://commons.wikimedia.org/wiki/Special:Redirect/file/Cute_rabbit.JPG)